### PR TITLE
Fix Speaches STT and custom TTS voices

### DIFF
--- a/src/pipecat/services/speaches/stt.py
+++ b/src/pipecat/services/speaches/stt.py
@@ -1,20 +1,25 @@
-"""Speaches STT Service — streams audio over WebSocket to a Speaches server."""
+"""Speaches STT Service — uses the OpenAI-compatible /v1/audio/transcriptions endpoint."""
 
 from dataclasses import dataclass
 from typing import Optional
 
-from pipecat.services.dograh.stt import DograhSTTService, DograhSTTSettings
+from pipecat.services.openai.stt import OpenAISTTService, OpenAISTTSettings
 
 
 @dataclass
-class SpeachesSTTSettings(DograhSTTSettings):
+class SpeachesSTTSettings(OpenAISTTSettings):
     """Settings for Speaches STT service."""
 
     pass
 
 
-class SpeachesSTTService(DograhSTTService):
-    """Speaches STT service that streams audio over WebSocket to a Speaches server."""
+class SpeachesSTTService(OpenAISTTService):
+    """Speaches STT service using the OpenAI-compatible transcription endpoint.
+
+    Speaches exposes ``/v1/audio/transcriptions`` with an OpenAI-compatible
+    multipart request format, so we can reuse the segmented HTTP STT adapter
+    instead of a custom websocket protocol.
+    """
 
     Settings = SpeachesSTTSettings
 
@@ -22,24 +27,13 @@ class SpeachesSTTService(DograhSTTService):
         self,
         *,
         api_key: str = "none",
-        base_url: str = "ws://localhost:8000/v1",
-        ws_path: str = "/stt/ws",
+        base_url: str = "http://localhost:8000/v1",
         settings: Optional[SpeachesSTTSettings] = None,
         **kwargs,
     ):
-        """Initialize the Speaches STT service.
-
-        Args:
-            api_key: API key for authentication.
-            base_url: Base WebSocket URL of the Speaches server.
-            ws_path: WebSocket path for STT streaming.
-            settings: Optional service settings.
-            **kwargs: Additional arguments passed to parent.
-        """
         super().__init__(
             api_key=api_key,
             base_url=base_url,
-            ws_path=ws_path,
             settings=settings,
             **kwargs,
         )

--- a/src/pipecat/services/speaches/tts.py
+++ b/src/pipecat/services/speaches/tts.py
@@ -3,7 +3,12 @@
 from dataclasses import dataclass
 from typing import Optional
 
+from loguru import logger
+from openai import BadRequestError
+
+from pipecat.frames.frames import ErrorFrame, Frame, TTSAudioRawFrame
 from pipecat.services.openai.tts import OpenAITTSService, OpenAITTSSettings
+from pipecat.utils.tracing.service_decorators import traced_tts
 
 
 @dataclass
@@ -43,3 +48,54 @@ class SpeachesTTSService(OpenAITTSService):
             settings=settings,
             **kwargs,
         )
+
+    @traced_tts
+    async def run_tts(self, text: str, context_id: str):
+        """Generate speech using the configured voice string as-is.
+
+        Speaches exposes an OpenAI-compatible API surface, but unlike OpenAI it
+        accepts provider-specific voice identifiers such as ``fettah``. The
+        upstream OpenAI service adapter maps voices through a fixed whitelist,
+        which breaks custom Speaches voices with a ``KeyError``.
+        """
+        logger.debug(f"{self}: Generating TTS [{text}]")
+        try:
+            create_params = {
+                "input": text,
+                "model": self._settings.model,
+                "voice": self._settings.voice,
+                "response_format": "pcm",
+            }
+
+            if self._settings.instructions:
+                create_params["instructions"] = self._settings.instructions
+
+            if self._settings.speed:
+                create_params["speed"] = self._settings.speed
+
+            async with self._client.audio.speech.with_streaming_response.create(
+                **create_params
+            ) as response:
+                if response.status_code != 200:
+                    error = await response.text()
+                    logger.error(
+                        f"{self} error getting audio (status: {response.status_code}, error: {error})"
+                    )
+                    yield ErrorFrame(
+                        error=f"Error getting audio (status: {response.status_code}, error: {error})"
+                    )
+                    return
+
+                await self.start_tts_usage_metrics(text)
+
+                async for chunk in response.iter_bytes(self.chunk_size):
+                    if len(chunk) > 0:
+                        await self.stop_ttfb_metrics()
+                        yield TTSAudioRawFrame(
+                            chunk,
+                            self.sample_rate,
+                            1,
+                            context_id=context_id,
+                        )
+        except BadRequestError as e:
+            yield ErrorFrame(error=f"Unknown error occurred: {e}")

--- a/tests/test_speaches_stt.py
+++ b/tests/test_speaches_stt.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+
+import pytest
+
+from pipecat.services.speaches.stt import SpeachesSTTService, SpeachesSTTSettings
+
+
+@pytest.mark.asyncio
+async def test_speaches_stt_uses_openai_compatible_transcription_request():
+    captured = {}
+
+    async def create(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(text="Merhaba")
+
+    service = SpeachesSTTService(
+        api_key="none",
+        base_url="http://localhost:9100/v1",
+        settings=SpeachesSTTSettings(
+            model="Systran/faster-whisper-small",
+            language="tr",
+        ),
+    )
+    service._client = SimpleNamespace(
+        audio=SimpleNamespace(
+            transcriptions=SimpleNamespace(
+                create=create,
+            )
+        )
+    )
+
+    result = await service._transcribe(b"wav-bytes")
+
+    assert result.text == "Merhaba"
+    assert captured["file"] == ("audio.wav", b"wav-bytes", "audio/wav")
+    assert captured["model"] == "Systran/faster-whisper-small"
+    assert captured["language"] == "tr"

--- a/tests/test_speaches_tts.py
+++ b/tests/test_speaches_tts.py
@@ -1,0 +1,84 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Tests for SpeachesTTSService."""
+
+import asyncio
+
+import pytest
+from aiohttp import web
+
+from pipecat.frames.frames import (
+    AggregatedTextFrame,
+    TTSAudioRawFrame,
+    TTSSpeakFrame,
+    TTSStartedFrame,
+    TTSStoppedFrame,
+    TTSTextFrame,
+)
+from pipecat.services.speaches.tts import SpeachesTTSService, SpeachesTTSSettings
+from pipecat.tests.utils import run_test
+
+
+@pytest.mark.asyncio
+async def test_run_speaches_tts_allows_custom_voice(aiohttp_client):
+    """Speaches should pass custom voice IDs through unchanged."""
+
+    request_bodies = []
+
+    async def handler(request):
+        request_bodies.append(await request.json())
+
+        response = web.StreamResponse(
+            status=200,
+            reason="OK",
+            headers={"Content-Type": "audio/pcm"},
+        )
+        await response.prepare(request)
+        await response.write(b"\x00\x01\x02\x03" * 1024)
+        await asyncio.sleep(0.01)
+        await response.write(b"\x04\x05\x06\x07" * 1024)
+        await response.write_eof()
+        return response
+
+    app = web.Application()
+    app.router.add_post("/v1/audio/speech", handler)
+    client = await aiohttp_client(app)
+    base_url = str(client.make_url("/v1"))
+
+    tts_service = SpeachesTTSService(
+        api_key="none",
+        base_url=base_url,
+        sample_rate=24000,
+        settings=SpeachesTTSSettings(
+            model="speaches-ai/piper-tr_TR-fettah-medium",
+            voice="fettah",
+        ),
+    )
+
+    down_frames, _ = await run_test(
+        tts_service,
+        frames_to_send=[TTSSpeakFrame(text="Merhaba dunya.")],
+    )
+
+    frame_types = [type(frame) for frame in down_frames]
+    assert AggregatedTextFrame in frame_types
+    assert TTSStartedFrame in frame_types
+    assert TTSStoppedFrame in frame_types
+    assert TTSTextFrame in frame_types
+
+    audio_frames = [frame for frame in down_frames if isinstance(frame, TTSAudioRawFrame)]
+    assert audio_frames
+    assert all(frame.sample_rate == 24000 for frame in audio_frames)
+    assert all(frame.num_channels == 1 for frame in audio_frames)
+
+    assert len(request_bodies) == 1
+    assert request_bodies[0] == {
+        "input": "Merhaba dunya.",
+        "model": "speaches-ai/piper-tr_TR-fettah-medium",
+        "voice": "fettah",
+        "response_format": "pcm",
+    }


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.
## What changed

This updates the Speaches adapters in `pipecat` so they match a stock Speaches server without requiring server-side compatibility shims.

## Why

Speaches exposes OpenAI-compatible HTTP endpoints for both transcription and speech generation, but the previous adapters had two integration mismatches:

- STT expected a custom websocket path instead of using `/v1/audio/transcriptions`
- TTS mapped `voice` through OpenAI's fixed voice whitelist, which breaks custom Speaches voices such as `fettah`

## Impact

Dograh deployments pointing at a Speaches server can now:

- use Speaches STT via the existing OpenAI-compatible transcription endpoint
- use custom Speaches TTS voice IDs directly

## Root cause

The Speaches adapters were inheriting behavior tailored to Dograh/OpenAI transport assumptions rather than Speaches' actual OpenAI-compatible API surface.

## Validation

- `python3 -m py_compile` on the updated adapter and test files
- Added focused regression tests for Speaches STT request shaping and custom TTS voice passthrough
- 
Companion Dograh PR: [<DOGRAH_PR_URL>](https://github.com/dograh-hq/pipecat/compare/main...drascom:codex/fix-speaches-adapters?expand=1)

Related discussion: [<DISCUSSION_URL>](https://github.com/orgs/dograh-hq/discussions/223)

This PR contains the adapter-level Speaches fixes. The Dograh PR depends on this landing first because it updates the service wiring and submodule pointer.
