### PR TITLE
fix: defer Gemini Live reconnect while tool_response is in flight

### DIFF
--- a/src/pipecat/services/google/gemini_live/llm.py
+++ b/src/pipecat/services/google/gemini_live/llm.py
@@ -524,6 +524,11 @@ class GeminiLiveLLMService(LLMService):
         self._user_is_muted = False
         self._reconnect_pending = False
         self._pending_function_calls = []
+        # Tool call IDs the server has emitted but for which we have not yet
+        # delivered a tool_response on the current session. Reconnecting while
+        # this set is non-empty would send the response to a session that
+        # never issued the call, leaving Gemini 3.x stuck in sync-call wait.
+        self._pending_tool_responses: set[str] = set()
         self._user_audio_buffer = bytearray()
         self._user_transcription_buffer = ""
         self._last_transcription_sent = ""
@@ -603,7 +608,11 @@ class GeminiLiveLLMService(LLMService):
             # First time setting system_instruction
             if not self._session:
                 await self._connect()
-            elif self._bot_is_responding:
+            elif self._bot_is_responding or self._pending_tool_responses:
+                # Defer reconnect: a reconnect mid-utterance truncates the
+                # bot turn, and a reconnect mid-tool-call strands the
+                # tool_response on a session that never issued the
+                # corresponding tool_call (hangs Gemini 3.x's sync calls).
                 self._reconnect_pending = True
             else:
                 await self._reconnect()
@@ -872,7 +881,11 @@ class GeminiLiveLLMService(LLMService):
         if not self._bot_is_responding and self._end_frame_pending_bot_turn_finished:
             await self._release_deferred_end_frame()
 
-        if not self._bot_is_responding and self._reconnect_pending:
+        if (
+            not self._bot_is_responding
+            and not self._pending_tool_responses
+            and self._reconnect_pending
+        ):
             self._reconnect_pending = False
             await self._reconnect()
 
@@ -1221,6 +1234,10 @@ class GeminiLiveLLMService(LLMService):
                 self._session = None
             self._session_ready_event.clear()
             self._ready_for_realtime_input = False
+            # Drop any tool_call_ids the previous session emitted — they're
+            # not deliverable on a new session and would otherwise block all
+            # future reconnects.
+            self._pending_tool_responses.clear()
             self._disconnecting = False
         except Exception as e:
             await self.push_error(error_msg=f"Error disconnecting: {e}", exception=e)
@@ -1456,6 +1473,15 @@ class GeminiLiveLLMService(LLMService):
                 await self._session.send_realtime_input(text=" ")
         except Exception as e:
             await self._handle_send_error(e)
+        finally:
+            # Drop the id whether or not the send raised — a stale entry
+            # would block all future reconnects. Reconnect is intentionally
+            # NOT fired here: under Gemini 3.x's sync contract the model
+            # responds on this session immediately after the tool_response,
+            # and tearing the session down now would truncate that response.
+            # _set_bot_is_responding(False) fires the deferred reconnect at
+            # the safe point (after the model's post-tool turn completes).
+            self._pending_tool_responses.discard(tool_call_id)
 
     @traced_gemini_live(operation="llm_setup")
     async def _handle_session_ready(self, session: AsyncSession):
@@ -1563,6 +1589,11 @@ class GeminiLiveLLMService(LLMService):
             )
             for f in function_calls
         ]
+
+        # Record that we owe the server a tool_response on this session
+        # for each call; _update_settings defers reconnects while non-empty.
+        for fc in function_calls_llm:
+            self._pending_tool_responses.add(fc.tool_call_id)
 
         if self._bot_is_responding:
             self._pending_function_calls = function_calls_llm

--- a/tests/test_gemini_live_tool_call_race.py
+++ b/tests/test_gemini_live_tool_call_race.py
@@ -1,0 +1,185 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""Regression test for the Gemini Live tool-call session-swap race.
+
+When `_update_settings(system_instruction=...)` is invoked between a
+`tool_call` arriving and its `tool_response` being delivered, the synchronous
+reconnect closes the originating session before the tool-result is sent. The
+subsequent `send_tool_response` then lands on a session that never emitted
+the matching `tool_call` — under Gemini 3.x's sync-only function-call
+contract the model is stranded.
+
+This test asserts the wire-protocol invariant directly:
+`send_tool_response(id=X)` reaches the `AsyncSession` instance that emitted
+`tool_call(id=X)`. The harness substitutes a `MockGeminiSession` for the real
+websocket; everything else (settings dispatch, function-call runner, deferred
+tool-call handling) runs unmodified.
+"""
+
+import asyncio
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from pipecat.clocks.system_clock import SystemClock
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.frame_processor import FrameProcessorSetup
+from pipecat.services.google.gemini_live.llm import GeminiLiveLLMService
+from pipecat.services.llm_service import FunctionCallParams
+from pipecat.services.settings import LLMSettings
+from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
+
+
+class MockGeminiSession:
+    """Records every send and is uniquely labelled per instance."""
+
+    _next_id = 0
+
+    def __init__(self):
+        type(self)._next_id += 1
+        self.label = f"session-{type(self)._next_id}"
+        self.sent_tool_responses: list = []
+        self.sent_realtime_inputs: list = []
+        self.sent_client_contents: list = []
+        self.closed = False
+
+    async def send_tool_response(self, function_responses):
+        self.sent_tool_responses.append(function_responses)
+
+    async def send_realtime_input(self, **kwargs):
+        self.sent_realtime_inputs.append(kwargs)
+
+    async def send_client_content(self, **kwargs):
+        self.sent_client_contents.append(kwargs)
+
+    async def close(self):
+        self.closed = True
+
+    def receive(self):
+        async def _empty():
+            if False:
+                yield None
+
+        return _empty()
+
+
+class HarnessedGeminiLiveLLMService(GeminiLiveLLMService):
+    """Replaces the real websocket connection with a `MockGeminiSession`.
+
+    Skips `_connection_task_handler` / receive loop so the test owns
+    message-arrival timing. Every other code path runs unmodified.
+    """
+
+    def __init__(self, *, sessions_log: list[MockGeminiSession], **kwargs):
+        super().__init__(**kwargs)
+        self._sessions_log = sessions_log
+
+    async def _connect(self, session_resumption_handle: str | None = None):
+        if self._session:
+            return
+        session = MockGeminiSession()
+        self._sessions_log.append(session)
+        await self._handle_session_ready(session)
+
+
+def _make_tool_call_message(call_id: str, name: str, args: dict | None = None):
+    """Duck-type a `LiveServerMessage` carrying a single tool_call."""
+    return SimpleNamespace(
+        tool_call=SimpleNamespace(
+            function_calls=[SimpleNamespace(id=call_id, name=name, args=args or {})]
+        )
+    )
+
+
+class TestGeminiLiveToolCallRace:
+    @pytest.mark.asyncio
+    async def test_send_tool_response_reaches_originating_session(self):
+        """tool_response(id=X) must reach the session that emitted tool_call(id=X).
+
+        Drives the production dispatch path: a tool_call arrives while the
+        bot is mid-utterance and is deferred; when the bot's utterance ends,
+        `_set_bot_is_responding(False)` triggers the function-call runner,
+        which invokes a registered handler that calls
+        `_update_settings(system_instruction=...)` then `result_callback(...)`.
+        The aggregator path that would normally translate the broadcast result
+        into `_tool_result(...)` is invoked manually at the end.
+
+        Without the `_pending_tool_responses` gating, `_update_settings`
+        reconnects synchronously, swapping `self._session` before
+        `_tool_result` runs.
+        """
+        sessions: list[MockGeminiSession] = []
+        service = HarnessedGeminiLiveLLMService(
+            sessions_log=sessions,
+            api_key=os.getenv("GOOGLE_API_KEY", "stub-value-mock-connect-bypasses-auth"),
+            system_instruction="initial node prompt",
+        )
+        # Force a Gemini 3.x model: the bug exists on 2.5 too but is only a
+        # hard hang on 3.x (sync-only function-call contract).
+        service._settings.model = "models/gemini-3.1-flash-live-preview"
+
+        service._context = LLMContext()
+
+        # `run_function_calls` schedules handlers via `self.task_manager`,
+        # which is populated by `FrameProcessor.setup`. Replicate the minimal
+        # init that production performs on StartFrame.
+        task_manager = TaskManager()
+        task_manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
+        await service.setup(FrameProcessorSetup(clock=SystemClock(), task_manager=task_manager))
+
+        handler_done = asyncio.Event()
+        handler_trace: list[str] = []
+
+        async def transition_func(params: FunctionCallParams):
+            handler_trace.append("entered")
+            await service._update_settings(LLMSettings(system_instruction="new node prompt"))
+            handler_trace.append("update_settings_returned")
+            await params.result_callback({"status": "ok"})
+            handler_trace.append("result_callback_returned")
+            handler_done.set()
+
+        service.register_function("advance_to_agent", transition_func)
+
+        await service._connect()
+        assert len(sessions) == 1
+        session_a = sessions[0]
+        assert service._session is session_a
+
+        # tool_call(X) arrives while bot is mid-utterance → deferred.
+        service._bot_is_responding = True
+        await service._handle_msg_tool_call(
+            _make_tool_call_message(call_id="X-call-id", name="advance_to_agent")
+        )
+
+        # Bot's utterance ends; production dispatch path runs the handler.
+        await service._set_bot_is_responding(False)
+        await asyncio.wait_for(handler_done.wait(), timeout=2.0)
+
+        session_at_result_time = service._session
+
+        # Aggregator stand-in: `FunctionCallResultFrame` would normally
+        # propagate through `LLMContextAggregator` to a context frame, which
+        # `_handle_context` consumes to call `_tool_result`. Without a
+        # `Pipeline` we invoke it directly.
+        await service._tool_result(
+            tool_call_id="X-call-id",
+            tool_name="advance_to_agent",
+            tool_result_message={"status": "ok"},
+        )
+
+        assert session_a.sent_tool_responses, (
+            "send_tool_response(id=X) did not reach the session that emitted "
+            "tool_call(id=X).\n"
+            f"  Handler progress:        {handler_trace}\n"
+            f"  Sessions opened:         {[s.label for s in sessions]}\n"
+            f"  Session A closed:        {session_a.closed}\n"
+            f"  Per-session sends:       "
+            f"{[(s.label, len(s.sent_tool_responses)) for s in sessions]}\n"
+            f"  service._session at _tool_result time: "
+            f"{getattr(session_at_result_time, 'label', None)}\n"
+        )


### PR DESCRIPTION
## Summary

Fixes a race in `GeminiLiveLLMService` where `_update_settings(system_instruction=...)` reconnects synchronously while a `tool_call` is in flight, stranding the eventual `send_tool_response` on a new session that never emitted the matching call. Under Gemini 3.x's sync-only function-call contract the model is then blocked indefinitely — visible in production as a workflow agent that announces a transition tool and then goes silent.

Full diagnosis with symptoms, mechanism, and SHA-anchored references: **dograh-hq/dograh#281**.

## Why the current code is wrong

`_update_settings` (at `gemini_live/llm.py:602-609`) defers the reconnect only while `self._bot_is_responding` is true. That predicate models "the bot is mid-utterance" but not "this session still owes the server a `tool_response`." When dograh's `transition_func` calls `set_node` mid-tool-call (which ends up calling `_update_settings`), the reconnect fires synchronously and `self._session` is swapped before `_tool_result` runs. The response then lands on a session that has no record of the originating `tool_call`.

On Gemini 2.5 the same code path was lossy but recoverable (async function calling). On 3.x the contract is sync-only and the model hangs.

## The fix

A protocol-level invariant — "`tool_response(X)` is bound to the session that emitted `tool_call(X)`" — is now encoded in service state:

- **New field:** `self._pending_tool_responses: set[str]` — call_ids emitted by the server on the current session that have not yet had a response delivered.
- **`_handle_msg_tool_call`** populates it as each `tool_call` arrives (before the existing deferred/dispatch split, so both paths track the same state).
- **`_update_settings`** now defers when `_bot_is_responding OR _pending_tool_responses` is non-empty.
- **`_tool_result`** discards the id in a `finally` after the send (whether or not the send raised). It does **not** fire the deferred reconnect — under the sync contract the model responds on this session immediately after the `tool_response`, and a reconnect at that moment would truncate the post-tool turn.
- **`_set_bot_is_responding(False)`** fires the deferred reconnect once both `_bot_is_responding` and `_pending_tool_responses` are clear — the safe point, after the model's post-tool turn ends.
- **`_disconnect`** clears the set (defense-in-depth: a connection-error reconnect via `_handle_connection_error` bypasses `_update_settings`'s gate, so without this clear, stale ids would persist into the new session and block every subsequent settings-driven reconnect).

Net diff: +33 / -2 in `gemini_live/llm.py`. No new abstractions, no API changes.

## Test

`tests/test_gemini_live_tool_call_race.py` — drives the production dispatch chain:

```
_handle_msg_tool_call(msg) while _bot_is_responding=True   # call deferred
→ _set_bot_is_responding(False)                            # real transition
→ _run_pending_function_calls
→ run_function_calls
→ registered handler that mirrors dograh's transition_func ordering:
    _update_settings(system_instruction=...) then result_callback(...)
```

Steps 1–3 in that chain run unmodified pipecat code. Only the aggregator path (`FunctionCallResultFrame` → `LLMContextAggregator` → `_tool_result`) is hand-rolled, by calling `_tool_result` directly at the end of the test, since there is no `Pipeline` in scope. The harness substitutes a `MockGeminiSession` for the real websocket so the session-identity assertion is mechanical.

On `main` (without this fix) the test fails with a diagnostic naming the swap. With the fix it passes.

```
$ uv run pytest tests/test_gemini_live_tool_call_race.py -v
tests/test_gemini_live_tool_call_race.py::TestGeminiLiveToolCallRace::test_send_tool_response_reaches_originating_session PASSED
```

## What's NOT in this PR

- **The connection-error reconnect at `gemini_live/llm.py:1138`** (`_handle_connection_error` → `_reconnect()`) is a separate bypass path that can also strand a `send_tool_response` on the wrong session, via a network-error trigger rather than a settings-driven one. It will be filed and patched separately; this PR's `_disconnect` cleanup makes that bypass non-catastrophic (no permanent deadlock) but doesn't redirect the stranded send. Scope-limited to the `set_node`-triggered race here.
- **Engine-side changes in `dograh`'s `pipecat_engine.py`.** The bug's trigger is in the engine's `set_node`-before-`result_callback` ordering, but that ordering is correct for cascaded-LLM services (it's load-bearing for `test_pipecat_engine_context_update.py::test_single_transition_updates_context_before_next_completion`). The contract violation is at the service layer; the fix belongs there.
- **The dograh-hq/dograh submodule pointer bump.** Once this merges, `dograh-hq/dograh` will need a `chore: bump pipecat` commit pointing its submodule at the merge commit — matching the existing pattern in that repo (most recently `abfb678b` and `4c69e137`). Happy to open that follow-up PR after merge, or leave it for the usual maintainer cadence — whichever you prefer.

## Conventions

- Ruff format + lint clean on both changed files.
- Conventional-commit message style (`fix: ...`) matching the fork's history.
- No changelog fragment included — the fork's `changelog/` directory only contains the template; happy to add `changelog/<PR-number>.fixed.md` if maintainers want.
- No new dependencies.
- No `--no-verify` / skipped hooks.

## Refs

- Issue: dograh-hq/dograh#281
- Buggy reconnect path introduced in: dograh-hq/pipecat@6954990a (*"fix: customize gemini live for pipeline"*, 2026-03-31)
- Pinned commit at issue time: dograh-hq/pipecat@0d0e3b3bc (*"chore: simplify tracing configuration"*, 2026-05-08)
- Related but distinct upstream bug fix: pipecat-ai/pipecat#4366 (post-tool-result realtime-input nudge for Gemini 3.x — already applied in our pinned commit, addresses a different "no inference" symptom)
