### PR TITLE
Allow string language codes in Sarvam STT

### DIFF
--- a/src/pipecat/services/sarvam/stt.py
+++ b/src/pipecat/services/sarvam/stt.py
@@ -79,6 +79,10 @@ def language_to_sarvam_language(language: Language) -> str:
         Language.OR_IN: "od-IN",
         Language.EN_IN: "en-IN",
         Language.AS_IN: "as-IN",
+        Language.UR_IN: "ur-IN",
+        Language.KOK_IN: "kok-IN",
+        Language.MAI_IN: "mai-IN",
+        Language.SD_IN: "sd-IN",
     }
 
     return resolve_language(language, LANGUAGE_MAP, use_base_code=False)
@@ -410,6 +414,8 @@ class SarvamSTTService(STTService):
         """Resolve the current language setting to a Sarvam language code string."""
         language = assert_given(self._settings.language)
         if language:
+            if isinstance(language, str):
+                return language
             return language_to_sarvam_language(language)
         return self._config.default_language
 

--- a/src/pipecat/services/sarvam/stt.py
+++ b/src/pipecat/services/sarvam/stt.py
@@ -414,6 +414,9 @@ class SarvamSTTService(STTService):
         """Resolve the current language setting to a Sarvam language code string."""
         language = assert_given(self._settings.language)
         if language:
+            # String passthrough for BCP-47 codes that have no Language enum entry                                                                                                                            
+            # (e.g. ne-IN, sat-IN). Sarvam accepts them directly per                                                                                                                                            
+            # https://docs.sarvam.ai/api-reference-docs/speech-to-text/transcribe
             if isinstance(language, str):
                 return language
             return language_to_sarvam_language(language)

--- a/tests/test_sarvam_stt.py
+++ b/tests/test_sarvam_stt.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import pytest
+
+from pipecat.services.sarvam.stt import SarvamSTTService, language_to_sarvam_language
+from pipecat.transcriptions.language import Language
+
+
+@pytest.mark.parametrize(
+    "language, expected",
+    [
+        (Language.HI_IN, "hi-IN"),
+        (Language.UR_IN, "ur-IN"),
+        (Language.KOK_IN, "kok-IN"),
+        (Language.MAI_IN, "mai-IN"),
+        (Language.SD_IN, "sd-IN"),
+    ],
+)
+def test_language_to_sarvam_language_maps_enum_values(language, expected):
+    assert language_to_sarvam_language(language) == expected
+
+
+@pytest.mark.parametrize("language_code", ["ne-IN", "sat-IN"])
+def test_get_language_string_passes_through_string_values(language_code):
+    service = SarvamSTTService(api_key="test-key")
+    service._settings.language = language_code
+
+    assert service._get_language_string() == language_code
+
+
+def test_get_language_string_resolves_enum_via_mapping():
+    service = SarvamSTTService(api_key="test-key")
+    service._settings.language = Language.HI_IN
+
+    assert service._get_language_string() == "hi-IN"
+
+
+def test_get_language_string_returns_model_default_when_unset():
+    service = SarvamSTTService(api_key="test-key")
+    service._settings.language = None
+
+    assert service._get_language_string() == service._config.default_language
+    assert service._config.default_language == "unknown"


### PR DESCRIPTION
## Summary
- Pass through BCP-47 string language codes in Sarvam STT
- Add language mappings for ur-IN, kok-IN, mai-IN, sd-IN (saaras:v3)

## Why
Dograh passes string language codes and new v3 language options from its STT config.
Without this, unmapped BCP-47 codes fail in `_get_language_string`.

## Related
Dograh PR (to follow): adds Sarvam LLM, STT model updates, and usage_info API