### PR TITLE
Add provisional VAD interruption strategy

### DIFF
--- a/src/pipecat/frames/frames.py
+++ b/src/pipecat/frames/frames.py
@@ -1041,6 +1041,20 @@ class InterruptionFrame(SystemFrame):
 
 
 @dataclass
+class BotOutputAudioPauseFrame(SystemFrame):
+    """Frame requesting output audio playback to pause without clearing buffers."""
+
+    pass
+
+
+@dataclass
+class BotOutputAudioResumeFrame(SystemFrame):
+    """Frame requesting paused output audio playback to resume."""
+
+    pass
+
+
+@dataclass
 class UserStartedSpeakingFrame(SystemFrame):
     """Frame indicating that the user turn has started.
 

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -1072,21 +1072,6 @@ class LLMUserAggregator(LLMContextAggregator):
 
         if should_mute_frame:
             logger.trace(f"{frame.name} suppressed - user currently muted")
-            # Turn-start signals suppressed here never reach the user turn
-            # strategy, so a provisional-VAD pause can't arm. Surface at DEBUG
-            # to disambiguate "strategy saw nothing" from "no VAD at all".
-            if isinstance(
-                frame,
-                (
-                    VADUserStartedSpeakingFrame,
-                    InterimTranscriptionFrame,
-                    TranscriptionFrame,
-                ),
-            ):
-                logger.debug(
-                    f"[provisional-vad] {self} muted → suppressed {frame.name} "
-                    "before it reached the turn strategy"
-                )
 
         should_mute_next_time = False
         for s in self._params.user_mute_strategies:

--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -1072,6 +1072,21 @@ class LLMUserAggregator(LLMContextAggregator):
 
         if should_mute_frame:
             logger.trace(f"{frame.name} suppressed - user currently muted")
+            # Turn-start signals suppressed here never reach the user turn
+            # strategy, so a provisional-VAD pause can't arm. Surface at DEBUG
+            # to disambiguate "strategy saw nothing" from "no VAD at all".
+            if isinstance(
+                frame,
+                (
+                    VADUserStartedSpeakingFrame,
+                    InterimTranscriptionFrame,
+                    TranscriptionFrame,
+                ),
+            ):
+                logger.debug(
+                    f"[provisional-vad] {self} muted → suppressed {frame.name} "
+                    "before it reached the turn strategy"
+                )
 
         should_mute_next_time = False
         for s in self._params.user_mute_strategies:

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -25,6 +25,8 @@ from pipecat.audio.mixers.base_audio_mixer import BaseAudioMixer
 from pipecat.audio.utils import create_stream_resampler, is_silence
 from pipecat.frames.frames import (
     AssistantImageRawFrame,
+    BotOutputAudioPauseFrame,
+    BotOutputAudioResumeFrame,
     BotSpeakingFrame,
     BotStartedSpeakingFrame,
     BotStoppedSpeakingFrame,
@@ -340,6 +342,9 @@ class BaseOutputTransport(FrameProcessor):
         elif isinstance(frame, InterruptionFrame):
             await self.push_frame(frame, direction)
             await self._handle_frame(frame)
+        elif isinstance(frame, (BotOutputAudioPauseFrame, BotOutputAudioResumeFrame)):
+            await self.push_frame(frame, direction)
+            await self._handle_frame(frame)
         elif isinstance(frame, OutputTransportMessageUrgentFrame):
             await self.send_message(frame)
         elif isinstance(frame, OutputDTMFUrgentFrame):
@@ -363,6 +368,10 @@ class BaseOutputTransport(FrameProcessor):
 
         if isinstance(frame, InterruptionFrame):
             await sender.handle_interruptions(frame)
+        elif isinstance(frame, BotOutputAudioPauseFrame):
+            await sender.handle_audio_pause(frame)
+        elif isinstance(frame, BotOutputAudioResumeFrame):
+            await sender.handle_audio_resume(frame)
         elif isinstance(frame, OutputAudioRawFrame):
             await sender.handle_audio_frame(frame)
         elif isinstance(frame, (OutputImageRawFrame, SpriteFrame)):
@@ -446,6 +455,9 @@ class BaseOutputTransport(FrameProcessor):
             self._audio_task: asyncio.Task | None = None
             self._video_task: asyncio.Task | None = None
             self._clock_task: asyncio.Task | None = None
+            self._audio_paused = False
+            self._audio_resume_event = asyncio.Event()
+            self._audio_resume_event.set()
 
             # If timestamps are equal, use this count to preserve the insertion order
             self._clock_queue_counter = itertools.count()
@@ -540,6 +552,8 @@ class BaseOutputTransport(FrameProcessor):
             Args:
                 _: The start interruption frame (unused).
             """
+            await self.handle_audio_resume(BotOutputAudioResumeFrame())
+
             # Cancel tasks.
             await self._cancel_clock_task()
             await self._cancel_video_task()
@@ -562,6 +576,28 @@ class BaseOutputTransport(FrameProcessor):
 
             # Let's send a bot stopped speaking if we have to.
             await self._bot_stopped_speaking()
+
+        async def handle_audio_pause(self, _: BotOutputAudioPauseFrame):
+            """Pause audio playback while preserving queued output frames."""
+            if self._audio_paused:
+                return
+
+            logger.debug(
+                f"Bot{f' [{self._destination}]' if self._destination else ''} output audio paused"
+            )
+            self._audio_paused = True
+            self._audio_resume_event.clear()
+
+        async def handle_audio_resume(self, _: BotOutputAudioResumeFrame):
+            """Resume paused audio playback."""
+            if not self._audio_paused:
+                return
+
+            logger.debug(
+                f"Bot{f' [{self._destination}]' if self._destination else ''} output audio resumed"
+            )
+            self._audio_paused = False
+            self._audio_resume_event.set()
 
         async def handle_audio_frame(self, frame: OutputAudioRawFrame):
             """Handle incoming audio frames by buffering and chunking.
@@ -765,14 +801,27 @@ class BaseOutputTransport(FrameProcessor):
             """
 
             async def without_mixer(vad_stop_secs: float) -> AsyncGenerator[Frame, None]:
+                pending_frame: Frame | None = None
                 while True:
+                    while self._audio_paused:
+                        await self._audio_resume_event.wait()
+
                     try:
-                        frame = await asyncio.wait_for(
-                            self._audio_queue.get(), timeout=vad_stop_secs
-                        )
+                        if pending_frame:
+                            frame = pending_frame
+                            pending_frame = None
+                        else:
+                            frame = await asyncio.wait_for(
+                                self._audio_queue.get(), timeout=vad_stop_secs
+                            )
+                            if self._audio_paused:
+                                pending_frame = frame
+                                continue
                         yield frame
                         self._audio_queue.task_done()
                     except TimeoutError:
+                        if self._audio_paused:
+                            continue
                         # Fallback: notify the bot stopped speaking upstream if necessary based on timeout.
                         await self._bot_stopped_speaking()
 
@@ -783,6 +832,16 @@ class BaseOutputTransport(FrameProcessor):
                 last_frame_time = 0
                 silence = b"\x00" * self._audio_chunk_size
                 while True:
+                    if self._audio_paused:
+                        frame = OutputAudioRawFrame(
+                            audio=await mixer.mix(silence),
+                            sample_rate=self._sample_rate,
+                            num_channels=self._params.audio_out_channels,
+                        )
+                        yield frame
+                        await asyncio.sleep(0)
+                        continue
+
                     try:
                         frame = self._audio_queue.get_nowait()
                         if isinstance(frame, OutputAudioRawFrame):

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -343,7 +343,7 @@ class BaseOutputTransport(FrameProcessor):
             await self.push_frame(frame, direction)
             await self._handle_frame(frame)
         elif isinstance(frame, (BotOutputAudioPauseFrame, BotOutputAudioResumeFrame)):
-            logger.debug(f"{self} Received BotOutputAudioPauseFrame, BotOutputAudioResumeFrame")
+            logger.debug(f"{self} Received {frame.__class__.__name__}")
             await self.push_frame(frame, direction)
             await self._handle_frame(frame)
         elif isinstance(frame, OutputTransportMessageUrgentFrame):
@@ -515,6 +515,12 @@ class BaseOutputTransport(FrameProcessor):
             # Let the sink tasks process the queue until they reach this EndFrame.
             await self._clock_queue.put((float("inf"), next(self._clock_queue_counter), frame))
             await self._audio_queue.put(frame)
+
+            # If output audio is paused, the audio task is blocked waiting to
+            # resume and will never read the EndFrame we just enqueued. Resume
+            # so the queue can drain to the EndFrame; otherwise the
+            # `await self._audio_task` below would block shutdown forever.
+            await self.handle_audio_resume(BotOutputAudioResumeFrame())
 
             # At this point we have enqueued an EndFrame and we need to wait for
             # that EndFrame to be processed by the audio and clock tasks. We

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -343,6 +343,7 @@ class BaseOutputTransport(FrameProcessor):
             await self.push_frame(frame, direction)
             await self._handle_frame(frame)
         elif isinstance(frame, (BotOutputAudioPauseFrame, BotOutputAudioResumeFrame)):
+            logger.debug(f"{self} Received BotOutputAudioPauseFrame, BotOutputAudioResumeFrame")
             await self.push_frame(frame, direction)
             await self._handle_frame(frame)
         elif isinstance(frame, OutputTransportMessageUrgentFrame):

--- a/src/pipecat/turns/user_start/__init__.py
+++ b/src/pipecat/turns/user_start/__init__.py
@@ -7,6 +7,7 @@
 from .base_user_turn_start_strategy import BaseUserTurnStartStrategy, UserTurnStartedParams
 from .external_user_turn_start_strategy import ExternalUserTurnStartStrategy
 from .min_words_user_turn_start_strategy import MinWordsUserTurnStartStrategy
+from .provisional_vad_user_turn_start_strategy import ProvisionalVADUserTurnStartStrategy
 from .transcription_user_turn_start_strategy import TranscriptionUserTurnStartStrategy
 from .vad_user_turn_start_strategy import VADUserTurnStartStrategy
 from .wake_phrase_user_turn_start_strategy import WakePhraseUserTurnStartStrategy
@@ -21,6 +22,7 @@ __all__ = [
     "ExternalUserTurnStartStrategy",
     "KrispVivaIPUserTurnStartStrategy",
     "MinWordsUserTurnStartStrategy",
+    "ProvisionalVADUserTurnStartStrategy",
     "TranscriptionUserTurnStartStrategy",
     "UserTurnStartedParams",
     "VADUserTurnStartStrategy",

--- a/src/pipecat/turns/user_start/provisional_vad_user_turn_start_strategy.py
+++ b/src/pipecat/turns/user_start/provisional_vad_user_turn_start_strategy.py
@@ -8,6 +8,7 @@
 
 import asyncio
 
+from loguru import logger
 from pipecat.frames.frames import (
     BotOutputAudioPauseFrame,
     BotOutputAudioResumeFrame,
@@ -69,57 +70,106 @@ class ProvisionalVADUserTurnStartStrategy(BaseUserTurnStartStrategy):
         self._locked_out_until_bot_stops = False
         self._bot_speaking = False
 
+    def _state_str(self) -> str:
+        """Compact snapshot of the strategy's decision state (diagnostic)."""
+        return (
+            f"bot_speaking={self._bot_speaking} "
+            f"pause_active={self._provisional_pause_active} "
+            f"locked_out={self._locked_out_until_bot_stops}"
+        )
+
     async def process_frame(self, frame: Frame) -> ProcessFrameResult:
         """Process an incoming frame to detect user turn start."""
         if isinstance(frame, BotStartedSpeakingFrame):
             self._bot_speaking = True
+            logger.debug(f"[provisional-vad] {self} BotStartedSpeaking → {self._state_str()}")
         elif isinstance(frame, BotStoppedSpeakingFrame):
+            logger.debug(
+                f"[provisional-vad] {self} BotStoppedSpeaking (before) → {self._state_str()}"
+            )
             await self._handle_bot_stopped_speaking()
         elif isinstance(frame, VADUserStartedSpeakingFrame):
+            logger.debug(f"[provisional-vad] {self} VADUserStartedSpeaking → {self._state_str()}")
             return await self._handle_vad_started()
         elif isinstance(frame, VADUserStoppedSpeakingFrame):
             # Keep the fixed provisional window measured from speech start.
-            pass
+            logger.debug(f"[provisional-vad] {self} VADUserStoppedSpeaking → {self._state_str()}")
         elif isinstance(frame, InterimTranscriptionFrame) and self._use_interim:
+            logger.debug(f"[provisional-vad] {self} InterimTranscription → {self._state_str()}")
             return await self._handle_transcription()
         elif isinstance(frame, TranscriptionFrame):
+            logger.debug(f"[provisional-vad] {self} Transcription → {self._state_str()}")
             return await self._handle_transcription()
 
         return ProcessFrameResult.CONTINUE
 
     async def _handle_vad_started(self) -> ProcessFrameResult:
         if not self._bot_speaking:
+            logger.debug(
+                f"[provisional-vad] {self} vad_started: bot NOT speaking "
+                "→ trigger user turn started immediately"
+            )
             await self.trigger_user_turn_started()
             return ProcessFrameResult.STOP
 
         if self._locked_out_until_bot_stops:
+            logger.debug(
+                f"[provisional-vad] {self} vad_started: locked out until bot stops → ignore"
+            )
             return ProcessFrameResult.CONTINUE
 
         if not self._provisional_pause_active:
             self._provisional_pause_active = True
+            logger.debug(
+                f"[provisional-vad] {self} vad_started: arming provisional pause "
+                "→ pushing BotOutputAudioPauseFrame downstream"
+            )
             await self.push_frame(BotOutputAudioPauseFrame(), FrameDirection.DOWNSTREAM)
             self._resume_task = self.create_task(
                 self._resume_after_timeout(), name="resume_after_timeout"
+            )
+        else:
+            logger.debug(
+                f"[provisional-vad] {self} vad_started: provisional pause already active → no-op"
             )
 
         return ProcessFrameResult.CONTINUE
 
     async def _handle_transcription(self) -> ProcessFrameResult:
         if self._locked_out_until_bot_stops and self._bot_speaking:
+            logger.debug(
+                f"[provisional-vad] {self} transcription: locked out + bot speaking "
+                "→ reset aggregation (ignore transcript)"
+            )
             await self.trigger_reset_aggregation()
             return ProcessFrameResult.CONTINUE
 
         if self._provisional_pause_active:
+            logger.debug(
+                f"[provisional-vad] {self} transcription: confirms active provisional pause "
+                "→ trigger user turn started"
+            )
             self._provisional_pause_active = False
             await self._cancel_resume_task()
             await self.trigger_user_turn_started()
             return ProcessFrameResult.STOP
 
+        # Fall-through: no pause was armed (and not locked out). This fires
+        # the user turn directly even if the bot is still speaking, because
+        # the pause is only ever armed from _handle_vad_started.
+        logger.debug(
+            f"[provisional-vad] {self} transcription: FALL-THROUGH → trigger user turn started "
+            f"({self._state_str()})"
+        )
         await self.trigger_user_turn_started()
         return ProcessFrameResult.STOP
 
     async def _handle_bot_stopped_speaking(self):
         if self._provisional_pause_active:
+            logger.debug(
+                f"[provisional-vad] {self} bot stopped while provisional pause active "
+                "→ resume output audio"
+            )
             await self._resume_output_audio()
 
         self._bot_speaking = False
@@ -132,6 +182,10 @@ class ProvisionalVADUserTurnStartStrategy(BaseUserTurnStartStrategy):
             await asyncio.sleep(self._pause_secs)
             if not self._provisional_pause_active:
                 return
+            logger.debug(
+                f"[provisional-vad] {self} provisional pause timed out after "
+                f"{self._pause_secs}s with no transcript → resume + lock out until bot stops"
+            )
             self._provisional_pause_active = False
             self._locked_out_until_bot_stops = True
             await self._resume_output_audio()

--- a/src/pipecat/turns/user_start/provisional_vad_user_turn_start_strategy.py
+++ b/src/pipecat/turns/user_start/provisional_vad_user_turn_start_strategy.py
@@ -8,7 +8,6 @@
 
 import asyncio
 
-from loguru import logger
 from pipecat.frames.frames import (
     BotOutputAudioPauseFrame,
     BotOutputAudioResumeFrame,
@@ -70,85 +69,47 @@ class ProvisionalVADUserTurnStartStrategy(BaseUserTurnStartStrategy):
         self._locked_out_until_bot_stops = False
         self._bot_speaking = False
 
-    def _state_str(self) -> str:
-        """Compact snapshot of the strategy's decision state (diagnostic)."""
-        return (
-            f"bot_speaking={self._bot_speaking} "
-            f"pause_active={self._provisional_pause_active} "
-            f"locked_out={self._locked_out_until_bot_stops}"
-        )
-
     async def process_frame(self, frame: Frame) -> ProcessFrameResult:
         """Process an incoming frame to detect user turn start."""
         if isinstance(frame, BotStartedSpeakingFrame):
             self._bot_speaking = True
-            logger.debug(f"[provisional-vad] {self} BotStartedSpeaking → {self._state_str()}")
         elif isinstance(frame, BotStoppedSpeakingFrame):
-            logger.debug(
-                f"[provisional-vad] {self} BotStoppedSpeaking (before) → {self._state_str()}"
-            )
             await self._handle_bot_stopped_speaking()
         elif isinstance(frame, VADUserStartedSpeakingFrame):
-            logger.debug(f"[provisional-vad] {self} VADUserStartedSpeaking → {self._state_str()}")
             return await self._handle_vad_started()
         elif isinstance(frame, VADUserStoppedSpeakingFrame):
             # Keep the fixed provisional window measured from speech start.
-            logger.debug(f"[provisional-vad] {self} VADUserStoppedSpeaking → {self._state_str()}")
+            pass
         elif isinstance(frame, InterimTranscriptionFrame) and self._use_interim:
-            logger.debug(f"[provisional-vad] {self} InterimTranscription → {self._state_str()}")
             return await self._handle_transcription()
         elif isinstance(frame, TranscriptionFrame):
-            logger.debug(f"[provisional-vad] {self} Transcription → {self._state_str()}")
             return await self._handle_transcription()
 
         return ProcessFrameResult.CONTINUE
 
     async def _handle_vad_started(self) -> ProcessFrameResult:
         if not self._bot_speaking:
-            logger.debug(
-                f"[provisional-vad] {self} vad_started: bot NOT speaking "
-                "→ trigger user turn started immediately"
-            )
             await self.trigger_user_turn_started()
             return ProcessFrameResult.STOP
 
         if self._locked_out_until_bot_stops:
-            logger.debug(
-                f"[provisional-vad] {self} vad_started: locked out until bot stops → ignore"
-            )
             return ProcessFrameResult.CONTINUE
 
         if not self._provisional_pause_active:
             self._provisional_pause_active = True
-            logger.debug(
-                f"[provisional-vad] {self} vad_started: arming provisional pause "
-                "→ pushing BotOutputAudioPauseFrame downstream"
-            )
             await self.push_frame(BotOutputAudioPauseFrame(), FrameDirection.DOWNSTREAM)
             self._resume_task = self.create_task(
                 self._resume_after_timeout(), name="resume_after_timeout"
-            )
-        else:
-            logger.debug(
-                f"[provisional-vad] {self} vad_started: provisional pause already active → no-op"
             )
 
         return ProcessFrameResult.CONTINUE
 
     async def _handle_transcription(self) -> ProcessFrameResult:
         if self._locked_out_until_bot_stops and self._bot_speaking:
-            logger.debug(
-                f"[provisional-vad] {self} transcription: locked out + bot speaking "
-                "→ reset aggregation (ignore transcript)"
-            )
             await self.trigger_reset_aggregation()
             return ProcessFrameResult.CONTINUE
 
         if self._provisional_pause_active:
-            logger.debug(
-                f"[provisional-vad] {self} transcription: confirms active provisional pause "
-                "→ trigger user turn started"
-            )
             self._provisional_pause_active = False
             await self._cancel_resume_task()
             await self.trigger_user_turn_started()
@@ -157,19 +118,11 @@ class ProvisionalVADUserTurnStartStrategy(BaseUserTurnStartStrategy):
         # Fall-through: no pause was armed (and not locked out). This fires
         # the user turn directly even if the bot is still speaking, because
         # the pause is only ever armed from _handle_vad_started.
-        logger.debug(
-            f"[provisional-vad] {self} transcription: FALL-THROUGH → trigger user turn started "
-            f"({self._state_str()})"
-        )
         await self.trigger_user_turn_started()
         return ProcessFrameResult.STOP
 
     async def _handle_bot_stopped_speaking(self):
         if self._provisional_pause_active:
-            logger.debug(
-                f"[provisional-vad] {self} bot stopped while provisional pause active "
-                "→ resume output audio"
-            )
             await self._resume_output_audio()
 
         self._bot_speaking = False
@@ -182,10 +135,6 @@ class ProvisionalVADUserTurnStartStrategy(BaseUserTurnStartStrategy):
             await asyncio.sleep(self._pause_secs)
             if not self._provisional_pause_active:
                 return
-            logger.debug(
-                f"[provisional-vad] {self} provisional pause timed out after "
-                f"{self._pause_secs}s with no transcript → resume + lock out until bot stops"
-            )
             self._provisional_pause_active = False
             self._locked_out_until_bot_stops = True
             await self._resume_output_audio()

--- a/src/pipecat/turns/user_start/provisional_vad_user_turn_start_strategy.py
+++ b/src/pipecat/turns/user_start/provisional_vad_user_turn_start_strategy.py
@@ -1,0 +1,151 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+"""User turn start strategy with provisional VAD pause before transcript confirmation."""
+
+import asyncio
+
+from pipecat.frames.frames import (
+    BotOutputAudioPauseFrame,
+    BotOutputAudioResumeFrame,
+    BotStartedSpeakingFrame,
+    BotStoppedSpeakingFrame,
+    Frame,
+    InterimTranscriptionFrame,
+    TranscriptionFrame,
+    VADUserStartedSpeakingFrame,
+    VADUserStoppedSpeakingFrame,
+)
+from pipecat.processors.frame_processor import FrameDirection
+from pipecat.turns.types import ProcessFrameResult
+from pipecat.turns.user_start.base_user_turn_start_strategy import BaseUserTurnStartStrategy
+
+
+class ProvisionalVADUserTurnStartStrategy(BaseUserTurnStartStrategy):
+    """Pause bot audio on VAD, but start the user turn only after transcription.
+
+    While the bot is speaking, a VAD speech-start signal pauses output audio
+    without broadcasting an interruption. If an interim or final transcript
+    arrives before ``pause_secs`` elapses, the strategy starts the user turn and
+    the user aggregator emits the normal ``InterruptionFrame``. If no transcript
+    arrives in that window, output audio resumes and further transcript-based
+    starts are ignored until the bot stops speaking.
+
+    When the bot is not speaking, VAD and transcript frames start the user turn
+    immediately, matching the normal fast-turn behavior.
+    """
+
+    def __init__(self, *, pause_secs: float = 1.0, use_interim: bool = True, **kwargs):
+        """Initialize the provisional VAD start strategy.
+
+        Args:
+            pause_secs: Seconds to pause bot output while waiting for a
+                transcript confirmation.
+            use_interim: Whether interim transcriptions confirm the user turn.
+            **kwargs: Additional keyword arguments.
+        """
+        super().__init__(**kwargs)
+        self._pause_secs = pause_secs
+        self._use_interim = use_interim
+
+        self._bot_speaking = False
+        self._provisional_pause_active = False
+        self._locked_out_until_bot_stops = False
+        self._resume_task: asyncio.Task | None = None
+
+    async def cleanup(self):
+        """Clean up strategy state."""
+        await super().cleanup()
+        await self._cancel_resume_task()
+
+    async def reset(self):
+        """Reset the strategy to its initial state."""
+        await super().reset()
+        await self._cancel_resume_task()
+        self._provisional_pause_active = False
+        self._locked_out_until_bot_stops = False
+        self._bot_speaking = False
+
+    async def process_frame(self, frame: Frame) -> ProcessFrameResult:
+        """Process an incoming frame to detect user turn start."""
+        if isinstance(frame, BotStartedSpeakingFrame):
+            self._bot_speaking = True
+        elif isinstance(frame, BotStoppedSpeakingFrame):
+            await self._handle_bot_stopped_speaking()
+        elif isinstance(frame, VADUserStartedSpeakingFrame):
+            return await self._handle_vad_started()
+        elif isinstance(frame, VADUserStoppedSpeakingFrame):
+            # Keep the fixed provisional window measured from speech start.
+            pass
+        elif isinstance(frame, InterimTranscriptionFrame) and self._use_interim:
+            return await self._handle_transcription()
+        elif isinstance(frame, TranscriptionFrame):
+            return await self._handle_transcription()
+
+        return ProcessFrameResult.CONTINUE
+
+    async def _handle_vad_started(self) -> ProcessFrameResult:
+        if not self._bot_speaking:
+            await self.trigger_user_turn_started()
+            return ProcessFrameResult.STOP
+
+        if self._locked_out_until_bot_stops:
+            return ProcessFrameResult.CONTINUE
+
+        if not self._provisional_pause_active:
+            self._provisional_pause_active = True
+            await self.push_frame(BotOutputAudioPauseFrame(), FrameDirection.DOWNSTREAM)
+            self._resume_task = self.create_task(
+                self._resume_after_timeout(), name="resume_after_timeout"
+            )
+
+        return ProcessFrameResult.CONTINUE
+
+    async def _handle_transcription(self) -> ProcessFrameResult:
+        if self._locked_out_until_bot_stops and self._bot_speaking:
+            await self.trigger_reset_aggregation()
+            return ProcessFrameResult.CONTINUE
+
+        if self._provisional_pause_active:
+            self._provisional_pause_active = False
+            await self._cancel_resume_task()
+            await self.trigger_user_turn_started()
+            return ProcessFrameResult.STOP
+
+        await self.trigger_user_turn_started()
+        return ProcessFrameResult.STOP
+
+    async def _handle_bot_stopped_speaking(self):
+        if self._provisional_pause_active:
+            await self._resume_output_audio()
+
+        self._bot_speaking = False
+        self._locked_out_until_bot_stops = False
+        self._provisional_pause_active = False
+        await self._cancel_resume_task()
+
+    async def _resume_after_timeout(self):
+        try:
+            await asyncio.sleep(self._pause_secs)
+            if not self._provisional_pause_active:
+                return
+            self._provisional_pause_active = False
+            self._locked_out_until_bot_stops = True
+            await self._resume_output_audio()
+        except asyncio.CancelledError:
+            return
+        finally:
+            current_task = asyncio.current_task()
+            if self._resume_task is current_task:
+                self._resume_task = None
+
+    async def _resume_output_audio(self):
+        await self.push_frame(BotOutputAudioResumeFrame(), FrameDirection.DOWNSTREAM)
+
+    async def _cancel_resume_task(self):
+        if self._resume_task and not self._resume_task.done():
+            await self.cancel_task(self._resume_task)
+        self._resume_task = None

--- a/src/pipecat/turns/user_start/provisional_vad_user_turn_start_strategy.py
+++ b/src/pipecat/turns/user_start/provisional_vad_user_turn_start_strategy.py
@@ -60,11 +60,22 @@ class ProvisionalVADUserTurnStartStrategy(BaseUserTurnStartStrategy):
         """Clean up strategy state."""
         await super().cleanup()
         await self._cancel_resume_task()
+        # The timeout task we just cancelled was the only remaining path that
+        # would resume output audio. If a pause is still armed, resume here so
+        # we don't leave the output transport paused after teardown.
+        if self._provisional_pause_active:
+            await self._resume_output_audio()
+        self._provisional_pause_active = False
 
     async def reset(self):
         """Reset the strategy to its initial state."""
         await super().reset()
         await self._cancel_resume_task()
+        # The timeout task we just cancelled was the only remaining path that
+        # would resume output audio. If a pause is still armed, resume here so
+        # we don't leave the output transport paused after the reset.
+        if self._provisional_pause_active:
+            await self._resume_output_audio()
         self._provisional_pause_active = False
         self._locked_out_until_bot_stops = False
         self._bot_speaking = False
@@ -112,6 +123,11 @@ class ProvisionalVADUserTurnStartStrategy(BaseUserTurnStartStrategy):
         if self._provisional_pause_active:
             self._provisional_pause_active = False
             await self._cancel_resume_task()
+            # Resume explicitly instead of relying on the InterruptionFrame that
+            # trigger_user_turn_started() emits: with enable_interruptions=False
+            # no interruption is broadcast, which would leave the transport
+            # paused. The later resume (if any) is idempotent on the transport.
+            await self._resume_output_audio()
             await self.trigger_user_turn_started()
             return ProcessFrameResult.STOP
 

--- a/tests/test_base_output_transport.py
+++ b/tests/test_base_output_transport.py
@@ -14,6 +14,8 @@ from unittest.mock import AsyncMock
 from pipecat.audio.mixers.base_audio_mixer import BaseAudioMixer
 from pipecat.clocks.system_clock import SystemClock
 from pipecat.frames.frames import (
+    BotOutputAudioPauseFrame,
+    BotOutputAudioResumeFrame,
     CancelFrame,
     CancelTaskFrame,
     Frame,
@@ -199,5 +201,92 @@ class TestBaseOutputTransportInterruptions(unittest.IsolatedAsyncioTestCase):
             # The queued bot audio was dropped by the reset.
             self.assertTrue(sender._audio_queue.empty())
             release_write.set()
+        finally:
+            await transport.cancel(CancelFrame())
+
+    async def test_audio_pause_preserves_queued_bot_audio_until_resume(self):
+        transport = await self._make_transport(mixer=None)
+        try:
+            sender = transport._media_senders[None]
+            write_started = asyncio.Event()
+            release_write = asyncio.Event()
+            written_audio: list[bytes] = []
+
+            async def slow_first_write(frame):
+                written_audio.append(frame.audio)
+                if len(written_audio) == 1:
+                    write_started.set()
+                    await release_write.wait()
+                return True
+
+            transport.write_audio_frame = AsyncMock(side_effect=slow_first_write)
+
+            audio_one = OutputAudioRawFrame(
+                audio=b"\x01\x02" * (sender.audio_chunk_size // 2),
+                sample_rate=sender.sample_rate,
+                num_channels=1,
+            )
+            await transport.process_frame(audio_one, FrameDirection.DOWNSTREAM)
+            await write_started.wait()
+
+            await transport.process_frame(BotOutputAudioPauseFrame(), FrameDirection.DOWNSTREAM)
+
+            audio_two = OutputAudioRawFrame(
+                audio=b"\x03\x04" * (sender.audio_chunk_size // 2),
+                sample_rate=sender.sample_rate,
+                num_channels=1,
+            )
+            await transport.process_frame(audio_two, FrameDirection.DOWNSTREAM)
+
+            release_write.set()
+            await asyncio.sleep(0.05)
+
+            self.assertEqual(len(written_audio), 1)
+            self.assertFalse(sender._audio_queue.empty())
+
+            await transport.process_frame(BotOutputAudioResumeFrame(), FrameDirection.DOWNSTREAM)
+
+            for _ in range(20):
+                if len(written_audio) >= 2:
+                    break
+                await asyncio.sleep(0.01)
+
+            self.assertEqual(len(written_audio), 2)
+            self.assertEqual(written_audio[1], audio_two.audio)
+        finally:
+            await transport.cancel(CancelFrame())
+
+    async def test_audio_pause_holds_audio_queued_after_pause(self):
+        transport = await self._make_transport(mixer=None)
+        try:
+            sender = transport._media_senders[None]
+            written_audio: list[bytes] = []
+
+            async def capture_write(frame):
+                written_audio.append(frame.audio)
+                return True
+
+            transport.write_audio_frame = AsyncMock(side_effect=capture_write)
+
+            await transport.process_frame(BotOutputAudioPauseFrame(), FrameDirection.DOWNSTREAM)
+
+            audio = OutputAudioRawFrame(
+                audio=b"\x05\x06" * (sender.audio_chunk_size // 2),
+                sample_rate=sender.sample_rate,
+                num_channels=1,
+            )
+            await transport.process_frame(audio, FrameDirection.DOWNSTREAM)
+            await asyncio.sleep(0.05)
+
+            self.assertEqual(written_audio, [])
+
+            await transport.process_frame(BotOutputAudioResumeFrame(), FrameDirection.DOWNSTREAM)
+
+            for _ in range(20):
+                if written_audio:
+                    break
+                await asyncio.sleep(0.01)
+
+            self.assertEqual(written_audio, [audio.audio])
         finally:
             await transport.cancel(CancelFrame())

--- a/tests/test_base_output_transport.py
+++ b/tests/test_base_output_transport.py
@@ -18,6 +18,7 @@ from pipecat.frames.frames import (
     BotOutputAudioResumeFrame,
     CancelFrame,
     CancelTaskFrame,
+    EndFrame,
     Frame,
     InterruptionFrame,
     MixerControlFrame,
@@ -110,8 +111,10 @@ class _PassthroughMixer(BaseAudioMixer):
 
 
 class TestBaseOutputTransportInterruptions(unittest.IsolatedAsyncioTestCase):
-    async def _make_transport(self, mixer: BaseAudioMixer | None = None) -> BaseOutputTransport:
-        params = TransportParams(audio_out_enabled=True, audio_out_mixer=mixer)
+    async def _make_transport(
+        self, mixer: BaseAudioMixer | None = None, **param_kwargs
+    ) -> BaseOutputTransport:
+        params = TransportParams(audio_out_enabled=True, audio_out_mixer=mixer, **param_kwargs)
         transport = BaseOutputTransport(params)
         transport.push_frame = AsyncMock()
         transport.write_audio_frame = AsyncMock(return_value=True)
@@ -290,3 +293,38 @@ class TestBaseOutputTransportInterruptions(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(written_audio, [audio.audio])
         finally:
             await transport.cancel(CancelFrame())
+
+    async def test_stop_while_paused_drains_queue_without_deadlock(self):
+        # A graceful EndFrame shutdown while output audio is paused must not
+        # hang: stop() resumes the audio task so it can drain to the EndFrame.
+        transport = await self._make_transport(mixer=None, audio_out_end_silence_secs=0)
+        stopped = False
+        try:
+            sender = transport._media_senders[None]
+            written_audio: list[bytes] = []
+
+            async def capture_write(frame):
+                written_audio.append(frame.audio)
+                return True
+
+            transport.write_audio_frame = AsyncMock(side_effect=capture_write)
+
+            await transport.process_frame(BotOutputAudioPauseFrame(), FrameDirection.DOWNSTREAM)
+
+            audio = OutputAudioRawFrame(
+                audio=b"\x07\x08" * (sender.audio_chunk_size // 2),
+                sample_rate=sender.sample_rate,
+                num_channels=1,
+            )
+            await transport.process_frame(audio, FrameDirection.DOWNSTREAM)
+
+            # Without the resume in stop(), the audio task stays blocked on the
+            # pause event, never reads the EndFrame, and this awaits forever.
+            await asyncio.wait_for(sender.stop(EndFrame()), timeout=5.0)
+            stopped = True
+
+            # The frame queued before shutdown is still delivered.
+            self.assertEqual(written_audio, [audio.audio])
+        finally:
+            if not stopped:
+                await transport.cancel(CancelFrame())

--- a/tests/test_user_turn_start_strategy.py
+++ b/tests/test_user_turn_start_strategy.py
@@ -245,7 +245,12 @@ class TestProvisionalVADUserTurnStartStrategy(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result, ProcessFrameResult.STOP)
         self.assertTrue(should_start)
-        self.assertEqual([type(frame) for frame in pushed_frames], [BotOutputAudioPauseFrame])
+        # Confirming the turn resumes output audio explicitly so the transport
+        # is unblocked even when interruptions are disabled.
+        self.assertEqual(
+            [type(frame) for frame in pushed_frames],
+            [BotOutputAudioPauseFrame, BotOutputAudioResumeFrame],
+        )
 
         await strategy.cleanup()
 
@@ -288,6 +293,79 @@ class TestProvisionalVADUserTurnStartStrategy(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(result, ProcessFrameResult.STOP)
         self.assertTrue(should_start)
+
+        await strategy.cleanup()
+
+    async def test_reset_during_provisional_pause_resumes_output_audio(self):
+        # A long pause window keeps the provisional pause armed so the only way
+        # the transport gets resumed is the reset() guard itself.
+        strategy = ProvisionalVADUserTurnStartStrategy(pause_secs=10.0)
+        await strategy.setup(self.task_manager)
+
+        pushed_frames = []
+
+        @strategy.event_handler("on_push_frame")
+        async def on_push_frame(strategy, frame, direction):
+            pushed_frames.append(frame)
+
+        await strategy.process_frame(BotStartedSpeakingFrame())
+        await strategy.process_frame(VADUserStartedSpeakingFrame())
+        self.assertIsInstance(pushed_frames[-1], BotOutputAudioPauseFrame)
+
+        await strategy.reset()
+
+        self.assertIsInstance(pushed_frames[-1], BotOutputAudioResumeFrame)
+
+        await strategy.cleanup()
+
+    async def test_cleanup_during_provisional_pause_resumes_output_audio(self):
+        strategy = ProvisionalVADUserTurnStartStrategy(pause_secs=10.0)
+        await strategy.setup(self.task_manager)
+
+        pushed_frames = []
+
+        @strategy.event_handler("on_push_frame")
+        async def on_push_frame(strategy, frame, direction):
+            pushed_frames.append(frame)
+
+        await strategy.process_frame(BotStartedSpeakingFrame())
+        await strategy.process_frame(VADUserStartedSpeakingFrame())
+        self.assertIsInstance(pushed_frames[-1], BotOutputAudioPauseFrame)
+
+        await strategy.cleanup()
+
+        self.assertIsInstance(pushed_frames[-1], BotOutputAudioResumeFrame)
+
+    async def test_transcript_resumes_output_audio_when_interruptions_disabled(self):
+        # With interruptions disabled, trigger_user_turn_started() emits no
+        # InterruptionFrame, so the strategy must resume the transport itself.
+        strategy = ProvisionalVADUserTurnStartStrategy(pause_secs=10.0, enable_interruptions=False)
+        await strategy.setup(self.task_manager)
+
+        pushed_frames = []
+        should_start = False
+
+        @strategy.event_handler("on_push_frame")
+        async def on_push_frame(strategy, frame, direction):
+            pushed_frames.append(frame)
+
+        @strategy.event_handler("on_user_turn_started")
+        async def on_user_turn_started(strategy, params):
+            nonlocal should_start
+            should_start = True
+
+        await strategy.process_frame(BotStartedSpeakingFrame())
+        await strategy.process_frame(VADUserStartedSpeakingFrame())
+        result = await strategy.process_frame(
+            InterimTranscriptionFrame(text="Hello", user_id="cat", timestamp="")
+        )
+
+        self.assertEqual(result, ProcessFrameResult.STOP)
+        self.assertTrue(should_start)
+        self.assertEqual(
+            [type(frame) for frame in pushed_frames],
+            [BotOutputAudioPauseFrame, BotOutputAudioResumeFrame],
+        )
 
         await strategy.cleanup()
 

--- a/tests/test_user_turn_start_strategy.py
+++ b/tests/test_user_turn_start_strategy.py
@@ -4,22 +4,30 @@
 # SPDX-License-Identifier: BSD 2-Clause License
 #
 
+import asyncio
 import unittest
+from unittest.mock import Mock
 
 from pipecat.frames.frames import (
+    BotOutputAudioPauseFrame,
+    BotOutputAudioResumeFrame,
     BotStartedSpeakingFrame,
+    BotStoppedSpeakingFrame,
     InterimTranscriptionFrame,
     TranscriptionFrame,
     UserStartedSpeakingFrame,
     VADUserStartedSpeakingFrame,
     VADUserStoppedSpeakingFrame,
 )
+from pipecat.turns.types import ProcessFrameResult
 from pipecat.turns.user_start import (
     ExternalUserTurnStartStrategy,
     MinWordsUserTurnStartStrategy,
+    ProvisionalVADUserTurnStartStrategy,
     TranscriptionUserTurnStartStrategy,
     VADUserTurnStartStrategy,
 )
+from pipecat.utils.asyncio.task_manager import TaskManager, TaskManagerParams
 
 
 class TestMinWordsInterruptionStrategy(unittest.IsolatedAsyncioTestCase):
@@ -181,6 +189,114 @@ class TestTranscriptionUserTurnStartStrategy(unittest.IsolatedAsyncioTestCase):
 
         await strategy.process_frame(TranscriptionFrame(text="Hello!", user_id="", timestamp="now"))
         self.assertTrue(should_start)
+
+
+class TestProvisionalVADUserTurnStartStrategy(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.task_manager = TaskManager()
+        self.task_manager.setup(TaskManagerParams(loop=asyncio.get_running_loop()))
+
+    async def test_vad_while_bot_speaking_pauses_without_starting_turn(self):
+        strategy = ProvisionalVADUserTurnStartStrategy(pause_secs=0.05)
+        await strategy.setup(self.task_manager)
+
+        pushed_frames = []
+        should_start = False
+
+        @strategy.event_handler("on_push_frame")
+        async def on_push_frame(strategy, frame, direction):
+            pushed_frames.append(frame)
+
+        @strategy.event_handler("on_user_turn_started")
+        async def on_user_turn_started(strategy, params):
+            nonlocal should_start
+            should_start = True
+
+        await strategy.process_frame(BotStartedSpeakingFrame())
+        result = await strategy.process_frame(VADUserStartedSpeakingFrame())
+
+        self.assertEqual(result, ProcessFrameResult.CONTINUE)
+        self.assertFalse(should_start)
+        self.assertIsInstance(pushed_frames[-1], BotOutputAudioPauseFrame)
+
+        await strategy.cleanup()
+
+    async def test_transcript_during_provisional_pause_starts_turn(self):
+        strategy = ProvisionalVADUserTurnStartStrategy(pause_secs=1.0)
+        await strategy.setup(self.task_manager)
+
+        pushed_frames = []
+        should_start = False
+
+        @strategy.event_handler("on_push_frame")
+        async def on_push_frame(strategy, frame, direction):
+            pushed_frames.append(frame)
+
+        @strategy.event_handler("on_user_turn_started")
+        async def on_user_turn_started(strategy, params):
+            nonlocal should_start
+            should_start = True
+
+        await strategy.process_frame(BotStartedSpeakingFrame())
+        await strategy.process_frame(VADUserStartedSpeakingFrame())
+        result = await strategy.process_frame(
+            InterimTranscriptionFrame(text="Hello", user_id="cat", timestamp="")
+        )
+
+        self.assertEqual(result, ProcessFrameResult.STOP)
+        self.assertTrue(should_start)
+        self.assertEqual([type(frame) for frame in pushed_frames], [BotOutputAudioPauseFrame])
+
+        await strategy.cleanup()
+
+    async def test_no_transcript_resumes_and_locks_out_until_bot_stops(self):
+        strategy = ProvisionalVADUserTurnStartStrategy(pause_secs=0.01)
+        await strategy.setup(self.task_manager)
+
+        pushed_frames = []
+        should_start = False
+        reset_aggregation = Mock()
+
+        @strategy.event_handler("on_push_frame")
+        async def on_push_frame(strategy, frame, direction):
+            pushed_frames.append(frame)
+
+        @strategy.event_handler("on_user_turn_started")
+        async def on_user_turn_started(strategy, params):
+            nonlocal should_start
+            should_start = True
+
+        @strategy.event_handler("on_reset_aggregation")
+        async def on_reset_aggregation(strategy):
+            reset_aggregation()
+
+        await strategy.process_frame(BotStartedSpeakingFrame())
+        await strategy.process_frame(VADUserStartedSpeakingFrame())
+        await self._wait_for_frame(pushed_frames, BotOutputAudioResumeFrame)
+
+        result = await strategy.process_frame(
+            InterimTranscriptionFrame(text="late", user_id="cat", timestamp="")
+        )
+
+        self.assertEqual(result, ProcessFrameResult.CONTINUE)
+        self.assertFalse(should_start)
+        reset_aggregation.assert_called_once()
+
+        await strategy.process_frame(BotStoppedSpeakingFrame())
+        result = await strategy.process_frame(
+            TranscriptionFrame(text="new", user_id="cat", timestamp="")
+        )
+        self.assertEqual(result, ProcessFrameResult.STOP)
+        self.assertTrue(should_start)
+
+        await strategy.cleanup()
+
+    async def _wait_for_frame(self, frames, frame_type):
+        for _ in range(20):
+            if any(isinstance(frame, frame_type) for frame in frames):
+                return
+            await asyncio.sleep(0.01)
+        self.fail(f"{frame_type.__name__} was not pushed")
 
 
 class TestExternalUserTurnStartStrategy(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a provisional VAD user-turn start strategy that pauses bot audio on VAD and starts the turn only after transcript confirmation. Output transport now supports safe pause/resume and guarantees resume on interrupts, transcript confirmation, reset/cleanup, and stop() so audio never gets stuck.

- **New Features**
  - Added `BotOutputAudioPauseFrame` and `BotOutputAudioResumeFrame`.
  - Base output transport supports paused audio: keeps queued frames without a mixer and emits silence with a mixer.
  - Introduced `ProvisionalVADUserTurnStartStrategy`: while the bot is speaking, VAD pauses; transcripts within `pause_secs` start; on timeout, audio resumes and transcripts are ignored until the bot stops; when not speaking, turns start immediately.

- **Bug Fixes**
  - Prevent stranded audio: strategy explicitly resumes on transcript confirmation (even when `enable_interruptions=False`) and during `reset()`/`cleanup()`.
  - Interruption handling and `stop()` now resume audio first so queues drain and shutdown doesn’t hang.
  - Paused-loop behavior refined: without mixer, pending frames are held and delivered after resume; with mixer, silence is emitted to preserve timing.

<sup>Written for commit 9360a266ce585e26f48cf5d06eecb795ecf67974. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/pipecat/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `ProvisionalVADUserTurnStartStrategy`, which pauses bot output audio on VAD and only commits to an interruption once a transcript is confirmed within a configurable window. It also adds `BotOutputAudioPauseFrame`/`BotOutputAudioResumeFrame` system frames and the supporting pause/resume gate in `BaseOutputTransport`.

- **New strategy**: `ProvisionalVADUserTurnStartStrategy` arms a pause on VAD-start while the bot is speaking, waits up to `pause_secs` for transcript confirmation, and locks out further attempts until the bot stops if the window expires.
- **Transport changes**: Both the mixer and non-mixer audio loops in `BaseOutputTransport` respect the new `_audio_paused` flag; `stop()` and `handle_interruptions()` explicitly resume before draining to avoid deadlocks.
- **State management fixes**: `reset()` and `cleanup()` now guard against leaving the transport paused, and `_handle_transcription` explicitly resumes before emitting the turn-started event so the transport is unblocked even when `enable_interruptions=False`.

<h3>Confidence Score: 4/5</h3>

Safe to merge with caution — the core pause/resume transport mechanism and the strategy's happy path are correct, but a concurrent timeout+bot-stop scenario can silently drop the resume frame and leave all subsequent bot audio permanently blocked.

The new strategy correctly handles the main flows (transcript confirms turn, timeout resumes, reset/cleanup guards). However, _resume_after_timeout clears _provisional_pause_active before completing await _resume_output_audio(). If BotStoppedSpeakingFrame arrives during that await, _handle_bot_stopped_speaking skips its own resume (flag is already False) and then cancels the task — injecting CancelledError into the in-flight push, swallowed silently. No resume frame is ever delivered and the transport stays blocked for all future bot turns.

src/pipecat/turns/user_start/provisional_vad_user_turn_start_strategy.py — specifically the ordering of _provisional_pause_active = False relative to await self._resume_output_audio() in _resume_after_timeout, and the _cancel_resume_task() call in _handle_bot_stopped_speaking.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/pipecat/turns/user_start/provisional_vad_user_turn_start_strategy.py | New strategy with provisional VAD pause/resume logic; contains a race between _resume_after_timeout and _handle_bot_stopped_speaking that can silently drop the BotOutputAudioResumeFrame and permanently block transport audio. |
| src/pipecat/transports/base_output.py | Adds _audio_paused/_audio_resume_event gate to both mixer and non-mixer audio loops; without_mixer correctly handles pending frames and task_done ordering; with_mixer correctly emits mixed silence during pause. |
| src/pipecat/frames/frames.py | Adds BotOutputAudioPauseFrame and BotOutputAudioResumeFrame as SystemFrame subtypes; straightforward, no issues. |
| tests/test_base_output_transport.py | Adds three new tests covering pause/resume of queued audio, hold-on-pause, and EndFrame shutdown while paused; all cover the intended behaviors. |
| tests/test_user_turn_start_strategy.py | Adds comprehensive ProvisionalVADUserTurnStartStrategy tests including timeout-lockout, reset/cleanup guards, and interruptions-disabled path. |
| src/pipecat/turns/user_start/__init__.py | Exports ProvisionalVADUserTurnStartStrategy; no issues. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant U as User (VAD/STT)
    participant S as ProvisionalVADStrategy
    participant T as BaseOutputTransport

    Note over S,T: Bot is speaking

    U->>S: VADUserStartedSpeakingFrame
    S->>T: BotOutputAudioPauseFrame
    S->>S: start _resume_task (pause_secs timeout)

    alt Transcript arrives within pause_secs
        U->>S: InterimTranscriptionFrame / TranscriptionFrame
        S->>S: cancel _resume_task
        S->>T: BotOutputAudioResumeFrame
        S->>S: trigger_user_turn_started()
        Note over T: Interruption clears queued bot audio
    else Timeout expires (no transcript)
        S->>S: _resume_after_timeout fires
        S->>T: BotOutputAudioResumeFrame
        S->>S: "_locked_out_until_bot_stops = True"
        Note over S: Transcripts ignored until bot stops speaking
    end

    Note over S,T: Bot stops speaking
    U->>S: BotStoppedSpeakingFrame
    S->>S: "_locked_out_until_bot_stops = False"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant U as User (VAD/STT)
    participant S as ProvisionalVADStrategy
    participant T as BaseOutputTransport

    Note over S,T: Bot is speaking

    U->>S: VADUserStartedSpeakingFrame
    S->>T: BotOutputAudioPauseFrame
    S->>S: start _resume_task (pause_secs timeout)

    alt Transcript arrives within pause_secs
        U->>S: InterimTranscriptionFrame / TranscriptionFrame
        S->>S: cancel _resume_task
        S->>T: BotOutputAudioResumeFrame
        S->>S: trigger_user_turn_started()
        Note over T: Interruption clears queued bot audio
    else Timeout expires (no transcript)
        S->>S: _resume_after_timeout fires
        S->>T: BotOutputAudioResumeFrame
        S->>S: "_locked_out_until_bot_stops = True"
        Note over S: Transcripts ignored until bot stops speaking
    end

    Note over S,T: Bot stops speaking
    U->>S: BotStoppedSpeakingFrame
    S->>S: "_locked_out_until_bot_stops = False"
```

</a>

<sub>Reviews (4): Last reviewed commit: ["fix: prevent provisional VAD pause from ..."](https://github.com/dograh-hq/pipecat/commit/9360a266ce585e26f48cf5d06eecb795ecf67974) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40461151)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->