### PR TITLE
fix: handle vonage call termination 204 status code as success

### DIFF
--- a/src/pipecat/serializers/vonage.py
+++ b/src/pipecat/serializers/vonage.py
@@ -247,7 +247,7 @@ class VonageFrameSerializer(FrameSerializer):
 
             async with aiohttp.ClientSession() as session:
                 async with session.put(endpoint, headers=headers, json=data) as response:
-                    if response.status == 200:
+                    if response.status in (200, 204):
                         logger.info(f"Successfully terminated Vonage call {self._call_uuid}")
                     elif response.status == 404:
                         logger.debug(f"Vonage call {self._call_uuid} was already terminated")

--- a/tests/test_sarvam_stt.py
+++ b/tests/test_sarvam_stt.py
@@ -6,6 +6,8 @@
 
 import pytest
 
+pytest.importorskip("sarvamai")
+
 from pipecat.services.sarvam.stt import SarvamSTTService, language_to_sarvam_language
 from pipecat.transcriptions.language import Language
 

--- a/tests/test_vonage_serializer.py
+++ b/tests/test_vonage_serializer.py
@@ -1,0 +1,65 @@
+#
+# Copyright (c) 2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from pipecat.serializers.vonage import VonageFrameSerializer
+
+
+class _FakeResponse:
+    status = 204
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return False
+
+    async def text(self):
+        raise AssertionError("204 Vonage hangup responses should not be treated as errors")
+
+
+class _FakeClientSession:
+    def __init__(self):
+        self.put_calls = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def put(self, endpoint, *, headers, json):
+        self.put_calls.append((endpoint, headers, json))
+        return _FakeResponse()
+
+
+@pytest.mark.asyncio
+async def test_vonage_hangup_treats_204_as_success():
+    session = _FakeClientSession()
+    fake_aiohttp = SimpleNamespace(ClientSession=lambda: session)
+    fake_jwt = SimpleNamespace(encode=lambda claims, private_key, algorithm: "token")
+
+    serializer = VonageFrameSerializer(
+        call_uuid="call-123",
+        application_id="app-123",
+        private_key="private-key",
+    )
+
+    with patch.dict(sys.modules, {"aiohttp": fake_aiohttp, "jwt": fake_jwt}):
+        await serializer._hang_up_call()
+
+    assert session.put_calls == [
+        (
+            "https://api.nexmo.com/v1/calls/call-123",
+            {"Authorization": "Bearer token", "Content-Type": "application/json"},
+            {"action": "hangup"},
+        )
+    ]


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.
- handle http status code 204 as success instead of error in vonage call termination

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat Vonage call termination responses with HTTP 204 as success to prevent false error handling and align with the API.

- **Bug Fixes**
  - Handle 204 No Content from the hangup endpoint as success (same as 200).
  - Tests: add 204 success test and skip Sarvam STT tests when `sarvamai` is missing.

<sup>Written for commit d49cdad4e2792aa903cebb3db0cea8bf2dee98de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/pipecat/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a false-error condition in the Vonage call hangup flow by treating HTTP 204 No Content as a success response alongside 200, and adds a test to guard against regression.

- **`vonage.py`**: `response.status == 200` is widened to `response.status in (200, 204)`, preventing the error-logging branch from firing on a valid Vonage 204 response.
- **`tests/test_vonage_serializer.py`**: New async test stubs `aiohttp` and `jwt`, sets the fake response status to 204, and uses a `text()` guard that raises `AssertionError` if the error branch is ever reached.
- **`tests/test_sarvam_stt.py`**: Adds `pytest.importorskip("sarvamai")` so the Sarvam tests are skipped when the optional dependency is not installed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal one-line status-code addition with an accompanying test, and no error-handling logic is removed.

The fix is surgically small: one status code added to an existing tuple, the rest of the hangup logic (404 handling, error logging, JWT generation) is untouched, and the new test exercises the exact code path being changed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/pipecat/serializers/vonage.py | Single-line fix: adds 204 to the accepted success status codes for the Vonage call hangup endpoint. |
| tests/test_vonage_serializer.py | New test file that exercises the 204 success path with a stub aiohttp session; the `text()` guard correctly ensures the error branch is not taken. |
| tests/test_sarvam_stt.py | Adds `pytest.importorskip("sarvamai")` so the suite skips gracefully when the optional dependency is absent. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant PC as Pipecat (VonageFrameSerializer)
    participant Vonage as Vonage API (api.nexmo.com)

    PC->>Vonage: "PUT /v1/calls/{call_uuid} {action: "hangup"}"
    alt HTTP 200 OK
        Vonage-->>PC: 200 OK
        PC->>PC: log info "Successfully terminated"
    else HTTP 204 No Content (new)
        Vonage-->>PC: 204 No Content
        PC->>PC: log info "Successfully terminated"
    else HTTP 404 Not Found
        Vonage-->>PC: 404 Not Found
        PC->>PC: log debug "Already terminated"
    else Other error
        Vonage-->>PC: 4xx/5xx
        PC->>PC: log error with status + body
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant PC as Pipecat (VonageFrameSerializer)
    participant Vonage as Vonage API (api.nexmo.com)

    PC->>Vonage: "PUT /v1/calls/{call_uuid} {action: "hangup"}"
    alt HTTP 200 OK
        Vonage-->>PC: 200 OK
        PC->>PC: log info "Successfully terminated"
    else HTTP 204 No Content (new)
        Vonage-->>PC: 204 No Content
        PC->>PC: log info "Successfully terminated"
    else HTTP 404 Not Found
        Vonage-->>PC: 404 Not Found
        PC->>PC: log debug "Already terminated"
    else Other error
        Vonage-->>PC: 4xx/5xx
        PC->>PC: log error with status + body
    end
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix: import error in test\_sarvam\_stt.py"](https://github.com/dograh-hq/pipecat/commit/d49cdad4e2792aa903cebb3db0cea8bf2dee98de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40485727)</sub>

<!-- /greptile_comment -->