### PR TITLE
chore: deprecate v1 billing

### DIFF
--- a/src/pipecat/services/dograh/flux/stt.py
+++ b/src/pipecat/services/dograh/flux/stt.py
@@ -29,7 +29,6 @@ from pipecat.services.dograh.mps_billing import (
     MPS_BILLING_VERSION_KEY,
     MPS_BILLING_VERSION_V2,
     get_correlation_id,
-    uses_mps_billing_v2,
 )
 from pipecat.services.websocket_service import WebsocketService
 
@@ -159,20 +158,13 @@ class DograhFluxSTTService(DeepgramFluxSTTBase, WebsocketService):
             start_metadata=self._start_metadata,
         )
 
-    def _uses_mps_billing_v2(self) -> bool:
-        return uses_mps_billing_v2(
-            explicit_correlation_id=self._correlation_id,
-            start_metadata=self._start_metadata,
-        )
-
     def _build_dograh_query_string(self) -> str:
         """Append MPS billing/correlation params to the inherited Flux query."""
         query = self._build_query_string()
         correlation_id = self._get_correlation_id()
         if correlation_id:
             query += "&" + urlencode({"correlation_id": correlation_id})
-            if self._uses_mps_billing_v2():
-                query += "&" + urlencode({MPS_BILLING_VERSION_KEY: MPS_BILLING_VERSION_V2})
+            query += "&" + urlencode({MPS_BILLING_VERSION_KEY: MPS_BILLING_VERSION_V2})
         return query
 
     # ------------------------------------------------------------------

--- a/src/pipecat/services/dograh/llm.py
+++ b/src/pipecat/services/dograh/llm.py
@@ -17,7 +17,6 @@ from pipecat.services.dograh.mps_billing import (
     MPS_BILLING_VERSION_KEY,
     MPS_BILLING_VERSION_V2,
     get_correlation_id,
-    uses_mps_billing_v2,
 )
 from pipecat.services.openai.base_llm import OpenAILLMInvocationParams, OpenAILLMSettings
 from pipecat.services.openai.llm import OpenAILLMService
@@ -89,12 +88,6 @@ class DograhLLMService(OpenAILLMService):
             start_metadata=self._start_metadata,
         )
 
-    def _uses_mps_billing_v2(self) -> bool:
-        return uses_mps_billing_v2(
-            explicit_correlation_id=self._correlation_id,
-            start_metadata=self._start_metadata,
-        )
-
     def build_chat_completion_params(self, params_from_context: OpenAILLMInvocationParams) -> dict:
         """Build parameters for chat completion request with workflow_run_id.
 
@@ -118,8 +111,7 @@ class DograhLLMService(OpenAILLMService):
                 params["metadata"] = {}
 
             params["metadata"]["correlation_id"] = correlation_id
-            if self._uses_mps_billing_v2():
-                params["metadata"][MPS_BILLING_VERSION_KEY] = MPS_BILLING_VERSION_V2
+            params["metadata"][MPS_BILLING_VERSION_KEY] = MPS_BILLING_VERSION_V2
 
         return params
 

--- a/src/pipecat/services/dograh/mps_billing.py
+++ b/src/pipecat/services/dograh/mps_billing.py
@@ -1,9 +1,11 @@
-from typing import Any, Mapping
+"""Helpers for attaching MPS billing metadata to Dograh service requests."""
+
+from collections.abc import Mapping
+from typing import Any
 
 MPS_CORRELATION_ID_METADATA_KEY = "mps_correlation_id"
 MPS_BILLING_VERSION_KEY = "mps_billing_version"
 MPS_BILLING_VERSION_V2 = "2"
-WORKFLOW_RUN_ID_METADATA_KEY = "workflow_run_id"
 
 
 def get_correlation_id(
@@ -11,6 +13,7 @@ def get_correlation_id(
     explicit_correlation_id: str | None,
     start_metadata: Mapping[str, Any] | None,
 ) -> str | None:
+    """Return the MPS-minted correlation id for this run, if any."""
     if explicit_correlation_id:
         return explicit_correlation_id
 
@@ -19,19 +22,6 @@ def get_correlation_id(
 
     correlation_id = start_metadata.get(MPS_CORRELATION_ID_METADATA_KEY)
     if correlation_id is None:
-        correlation_id = start_metadata.get(WORKFLOW_RUN_ID_METADATA_KEY)
-    if correlation_id is None:
         return None
 
     return str(correlation_id)
-
-
-def uses_mps_billing_v2(
-    *,
-    explicit_correlation_id: str | None,
-    start_metadata: Mapping[str, Any] | None,
-) -> bool:
-    return bool(
-        explicit_correlation_id
-        or (start_metadata and start_metadata.get(MPS_CORRELATION_ID_METADATA_KEY))
-    )

--- a/src/pipecat/services/dograh/stt.py
+++ b/src/pipecat/services/dograh/stt.py
@@ -31,7 +31,6 @@ from pipecat.services.dograh.mps_billing import (
     MPS_BILLING_VERSION_KEY,
     MPS_BILLING_VERSION_V2,
     get_correlation_id,
-    uses_mps_billing_v2,
 )
 from pipecat.services.settings import STTSettings
 from pipecat.services.stt_latency import DOGRAH_TTFS_P99
@@ -154,12 +153,6 @@ class DograhSTTService(STTService, WebsocketService):
             start_metadata=self._start_metadata,
         )
 
-    def _uses_mps_billing_v2(self) -> bool:
-        return uses_mps_billing_v2(
-            explicit_correlation_id=self._correlation_id,
-            start_metadata=self._start_metadata,
-        )
-
     async def _connect_websocket(self):
         """Connect to the WebSocket endpoint."""
         try:
@@ -193,8 +186,7 @@ class DograhSTTService(STTService, WebsocketService):
             correlation_id = self._get_correlation_id()
             if correlation_id:
                 config_msg["correlation_id"] = correlation_id
-                if self._uses_mps_billing_v2():
-                    config_msg[MPS_BILLING_VERSION_KEY] = MPS_BILLING_VERSION_V2
+                config_msg[MPS_BILLING_VERSION_KEY] = MPS_BILLING_VERSION_V2
 
             await ws.send(json.dumps(config_msg))
 

--- a/src/pipecat/services/dograh/tts.py
+++ b/src/pipecat/services/dograh/tts.py
@@ -31,7 +31,6 @@ from pipecat.services.dograh.mps_billing import (
     MPS_BILLING_VERSION_KEY,
     MPS_BILLING_VERSION_V2,
     get_correlation_id,
-    uses_mps_billing_v2,
 )
 from pipecat.services.settings import NOT_GIVEN, TTSSettings, _NotGiven
 from pipecat.services.tts_service import TextAggregationMode, WebsocketTTSService
@@ -193,12 +192,6 @@ class DograhTTSService(WebsocketTTSService):
             start_metadata=self._start_metadata,
         )
 
-    def _uses_mps_billing_v2(self) -> bool:
-        return uses_mps_billing_v2(
-            explicit_correlation_id=self._correlation_id,
-            start_metadata=self._start_metadata,
-        )
-
     async def _connect_websocket(self):
         """Establish the websocket connection to Dograh TTS service."""
         try:
@@ -231,8 +224,7 @@ class DograhTTSService(WebsocketTTSService):
             correlation_id = self._get_correlation_id()
             if correlation_id:
                 config_msg["correlation_id"] = correlation_id
-                if self._uses_mps_billing_v2():
-                    config_msg[MPS_BILLING_VERSION_KEY] = MPS_BILLING_VERSION_V2
+                config_msg[MPS_BILLING_VERSION_KEY] = MPS_BILLING_VERSION_V2
 
             await ws.send(json.dumps(config_msg))
 
@@ -473,8 +465,7 @@ class DograhTTSService(WebsocketTTSService):
                     correlation_id = self._get_correlation_id()
                     if correlation_id:
                         context_msg["correlation_id"] = correlation_id
-                        if self._uses_mps_billing_v2():
-                            context_msg[MPS_BILLING_VERSION_KEY] = MPS_BILLING_VERSION_V2
+                        context_msg[MPS_BILLING_VERSION_KEY] = MPS_BILLING_VERSION_V2
 
                     await self._get_websocket().send(json.dumps(context_msg))
                     self._remote_initialized_context_ids.add(context_id)


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deprecates MPS billing v1 and standardizes v2 across Dograh services. We now always send billing v2 when a correlation ID is present, simplifying request logic and metadata handling.

- **Refactors**
  - Remove `uses_mps_billing_v2`; always include `mps_billing_version=2` when `correlation_id` is set.
  - Update `get_correlation_id` to use only explicit IDs or `mps_correlation_id` from `start_metadata` (drop `workflow_run_id` fallback).
  - Clean up imports and conditional code in `llm.py`, `stt.py`, `tts.py`, and `flux/stt.py`.

- **Migration**
  - If you relied on `workflow_run_id` for correlation, pass `mps_correlation_id` or an explicit correlation ID instead.
  - No other changes needed; v2 billing is applied automatically.

<sup>Written for commit 629d184d47cbcf510d3d5f674ddb8d9f567e4a2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/pipecat/pull/49?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes legacy v1 billing selection from Dograh service requests. The main changes are:

- Resolves billing correlation IDs only from explicit IDs or `mps_correlation_id` metadata.
- Stops falling back to `workflow_run_id` for Dograh MPS billing correlation.
- Always sends `mps_billing_version=2` when a Dograh request includes a correlation ID.
- Applies the billing metadata behavior across LLM, STT, TTS, and Flux STT paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The updated billing metadata behavior is small, consistent across the changed Dograh services, and no runtime or security bugs were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I ran the general contract validation harness against HEAD^ and observed a failure caused by workflow-only metadata producing correlation\_id=wf-legacy.
- I re-ran the harness against the current HEAD and confirmed all assertions passed after omitting the workflow-only metadata and carrying mps\_billing\_version: "2".
- I included the executable harness used for validation and attached the two evidence logs showing before and after results.

<a href="https://app.greptile.com/trex/runs/13534174/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/pipecat/services/dograh/mps_billing.py | Simplifies Dograh MPS billing helpers to resolve only MPS correlation IDs and always represent billing as v2 when a correlation ID exists. |
| src/pipecat/services/dograh/llm.py | Updates Dograh LLM metadata construction to attach `mps_billing_version=2` whenever a correlation ID is sent. |
| src/pipecat/services/dograh/stt.py | Updates Dograh STT WebSocket config messages to always include v2 billing metadata with correlation IDs. |
| src/pipecat/services/dograh/tts.py | Updates Dograh TTS connection and per-context setup messages to always include v2 billing metadata with correlation IDs. |
| src/pipecat/services/dograh/flux/stt.py | Updates Dograh Flux STT query-string billing parameters to always mark correlated requests as MPS billing v2. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Pipeline as Pipecat Pipeline
participant Service as Dograh Service
participant Billing as mps_billing.get_correlation_id
participant MPS as Dograh MPS

Pipeline->>Service: StartFrame(metadata)
Service->>Service: Store start metadata
Service->>Billing: Resolve explicit or mps_correlation_id
Billing-->>Service: correlation_id or None
alt correlation_id present
    Service->>MPS: Send request/config with correlation_id
    Service->>MPS: "Include mps_billing_version=2"
else no correlation_id
    Service->>MPS: Send request/config without billing metadata
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Pipeline as Pipecat Pipeline
participant Service as Dograh Service
participant Billing as mps_billing.get_correlation_id
participant MPS as Dograh MPS

Pipeline->>Service: StartFrame(metadata)
Service->>Service: Store start metadata
Service->>Billing: Resolve explicit or mps_correlation_id
Billing-->>Service: correlation_id or None
alt correlation_id present
    Service->>MPS: Send request/config with correlation_id
    Service->>MPS: "Include mps_billing_version=2"
else no correlation_id
    Service->>MPS: Send request/config without billing metadata
end
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore: deprecate v1 billing"](https://github.com/dograh-hq/pipecat/commit/629d184d47cbcf510d3d5f674ddb8d9f567e4a2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42346525)</sub>

<!-- /greptile_comment -->