### PR TITLE
Add transfer support for Cloudonix serializer

### DIFF
--- a/src/pipecat/serializers/cloudonix.py
+++ b/src/pipecat/serializers/cloudonix.py
@@ -7,7 +7,7 @@ from loguru import logger
 from pipecat.serializers.twilio import TwilioFrameSerializer
 
 if TYPE_CHECKING:
-    from pipecat.serializers.call_strategies import HangupStrategy
+    from pipecat.serializers.call_strategies import HangupStrategy, TransferStrategy
 
 
 class CloudonixFrameSerializer(TwilioFrameSerializer):
@@ -27,6 +27,7 @@ class CloudonixFrameSerializer(TwilioFrameSerializer):
         region: str | None = None,
         edge: str | None = None,
         hangup_strategy: "HangupStrategy | None" = None,
+        transfer_strategy: "TransferStrategy | None" = None,
         params: TwilioFrameSerializer.InputParams | None = None,
     ):
         """Initialize the CloudonixFrameSerializer.
@@ -41,6 +42,9 @@ class CloudonixFrameSerializer(TwilioFrameSerializer):
             hangup_strategy: Strategy for handling call hangups. The strategy receives
                 context with Twilio-compatible keys (call_sid, account_sid, auth_token)
                 mapped from Cloudonix values (call_id, domain_id, bearer_token).
+            transfer_strategy: Strategy for handling call transfers, invoked on an
+                EndFrame carrying the transfer reason. Receives the same
+                Twilio-compatible context keys as ``hangup_strategy``.
             params: Configuration parameters.
         """
         self._call_id = call_id
@@ -55,6 +59,7 @@ class CloudonixFrameSerializer(TwilioFrameSerializer):
             region=region,
             edge=edge,
             hangup_strategy=hangup_strategy,
+            transfer_strategy=transfer_strategy,
             params=params,
         )
 


### PR DESCRIPTION
Added the transfer strategy to the Cloudonix serializer, in conjunction with transfer support in main Dograh repository.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds transfer support to `CloudonixFrameSerializer`. The serializer now accepts an optional `transfer_strategy` to handle call transfers and passes it to the Twilio serializer, invoked on `EndFrame` with a transfer reason.

- **New Features**
  - Added `transfer_strategy: TransferStrategy | None` to the constructor.
  - The strategy receives Twilio-compatible context keys (`call_sid`, `account_sid`, `auth_token`) mapped from Cloudonix (`call_id`, `domain_id`, `bearer_token`).

<sup>Written for commit 71f18bbe98c6750b5883851d6f5bb88f1ac05165. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/pipecat/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds transfer support to the Cloudonix serializer. The main changes are:

- Adds an optional `transfer_strategy` constructor argument to `CloudonixFrameSerializer`.
- Forwards the strategy to the Twilio-compatible base serializer.
- Documents that transfer and hangup strategies receive the same mapped Cloudonix call context.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge with minimal risk.

The change is narrowly scoped to constructor typing, documentation, and forwarding an optional strategy into existing base-class transfer handling. No correctness or security issues were identified in the changed path.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Before proof shows the pre-change Cloudonix constructor rejected transfer\_strategy with TypeError.
- After proof shows the code compiled successfully, performed one transfer invocation, and captured runtime context including call\_sid cloud-call-123, account\_sid cloud-domain-789, redacted auth\_token, and preserved region, edge, and base\_url metadata.

<a href="https://app.greptile.com/trex/runs/14511043/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/pipecat/serializers/cloudonix.py | Adds an optional Cloudonix transfer strategy parameter and forwards it to the Twilio-compatible base serializer with matching context documentation. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant App as Application
participant Cloudonix as CloudonixFrameSerializer
participant Twilio as TwilioFrameSerializer
participant Strategy as TransferStrategy

App->>Cloudonix: __init__(..., transfer_strategy)
Cloudonix->>Twilio: "__init__(call_sid=call_id, account_sid=domain_id, auth_token=bearer_token, transfer_strategy)"
App->>Twilio: "serialize(EndFrame reason=TRANSFER_CALL)"
Twilio->>Strategy: execute_transfer(context)
Strategy-->>Twilio: success/failure
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant App as Application
participant Cloudonix as CloudonixFrameSerializer
participant Twilio as TwilioFrameSerializer
participant Strategy as TransferStrategy

App->>Cloudonix: __init__(..., transfer_strategy)
Cloudonix->>Twilio: "__init__(call_sid=call_id, account_sid=domain_id, auth_token=bearer_token, transfer_strategy)"
App->>Twilio: "serialize(EndFrame reason=TRANSFER_CALL)"
Twilio->>Strategy: execute_transfer(context)
Strategy-->>Twilio: success/failure
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Add transfer support for Cloudonix seria..."](https://github.com/dograh-hq/pipecat/commit/71f18bbe98c6750b5883851d6f5bb88f1ac05165) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44391734)</sub>

<!-- /greptile_comment -->