### PR TITLE
feat(plivo): add transfer and hangup strategies to serializer

### DIFF
--- a/src/pipecat/serializers/plivo.py
+++ b/src/pipecat/serializers/plivo.py
@@ -8,7 +8,7 @@
 
 import base64
 import json
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
 from loguru import logger
 
@@ -27,6 +27,10 @@ from pipecat.frames.frames import (
     StartFrame,
 )
 from pipecat.serializers.base_serializer import FrameSerializer
+from pipecat.utils.enums import EndTaskReason
+
+if TYPE_CHECKING:
+    from pipecat.serializers.call_strategies import HangupStrategy, TransferStrategy
 
 
 class PlivoFrameSerializer(FrameSerializer):
@@ -61,6 +65,8 @@ class PlivoFrameSerializer(FrameSerializer):
         call_id: str | None = None,
         auth_id: str | None = None,
         auth_token: str | None = None,
+        transfer_strategy: "TransferStrategy | None" = None,
+        hangup_strategy: "HangupStrategy | None" = None,
         params: InputParams | None = None,
     ):
         """Initialize the PlivoFrameSerializer.
@@ -70,6 +76,8 @@ class PlivoFrameSerializer(FrameSerializer):
             call_id: The associated Plivo Call ID (optional, but required for auto hang-up).
             auth_id: Plivo auth ID (required for auto hang-up).
             auth_token: Plivo auth token (required for auto hang-up).
+            transfer_strategy: Strategy invoked when the pipeline ends for a transfer.
+            hangup_strategy: Strategy invoked for ordinary pipeline termination.
             params: Configuration parameters.
         """
         params = params or PlivoFrameSerializer.InputParams()
@@ -95,6 +103,8 @@ class PlivoFrameSerializer(FrameSerializer):
         self._call_id = call_id
         self._auth_id = auth_id
         self._auth_token = auth_token
+        self._transfer_strategy = transfer_strategy
+        self._hangup_strategy = hangup_strategy
 
         self._plivo_sample_rate = self._params.plivo_sample_rate
         self._sample_rate = 0  # Pipeline input rate
@@ -106,6 +116,7 @@ class PlivoFrameSerializer(FrameSerializer):
             clear_after_secs=self._params.resampler_clear_after_secs
         )
         self._hangup_attempted = False
+        self._transfer_attempted = False
 
     async def setup(self, frame: StartFrame):
         """Sets up the serializer with pipeline configuration.
@@ -127,13 +138,34 @@ class PlivoFrameSerializer(FrameSerializer):
         Returns:
             Serialized data as string or bytes, or None if the frame isn't handled.
         """
-        if (
-            self._params.auto_hang_up
-            and not self._hangup_attempted
-            and isinstance(frame, (EndFrame, CancelFrame))
-        ):
-            self._hangup_attempted = True
-            await self._hang_up_call()
+        if isinstance(frame, (EndFrame, CancelFrame)):
+            frame_reason = getattr(frame, "reason", None)
+            context = {
+                "call_id": self._call_id,
+                "auth_id": self._auth_id,
+                "auth_token": self._auth_token,
+            }
+
+            if frame_reason == EndTaskReason.TRANSFER_CALL.value and not self._transfer_attempted:
+                self._transfer_attempted = True
+                if self._transfer_strategy:
+                    success = await self._transfer_strategy.execute_transfer(context)
+                    if not success:
+                        logger.error(f"Transfer strategy failed for Plivo call {self._call_id}")
+                else:
+                    logger.warning(
+                        f"No transfer strategy configured for Plivo call {self._call_id}"
+                    )
+                return None
+
+            if self._params.auto_hang_up and not self._hangup_attempted:
+                self._hangup_attempted = True
+                if self._hangup_strategy:
+                    success = await self._hangup_strategy.execute_hangup(context)
+                    if not success:
+                        logger.error(f"Hangup strategy failed for Plivo call {self._call_id}")
+                else:
+                    await self._hang_up_call()
             return None
         elif isinstance(frame, InterruptionFrame):
             answer = {"event": "clearAudio", "streamId": self._stream_id}

--- a/tests/test_plivo_serializer_strategies.py
+++ b/tests/test_plivo_serializer_strategies.py
@@ -1,0 +1,48 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from pipecat.frames.frames import EndFrame
+from pipecat.serializers.plivo import PlivoFrameSerializer
+from pipecat.utils.enums import EndTaskReason
+
+
+def _serializer(transfer_strategy, hangup_strategy):
+    return PlivoFrameSerializer(
+        stream_id="stream-1",
+        call_id="call-1",
+        auth_id="MA123",
+        auth_token="secret",
+        transfer_strategy=transfer_strategy,
+        hangup_strategy=hangup_strategy,
+    )
+
+
+@pytest.mark.asyncio
+async def test_transfer_end_frame_invokes_only_transfer_strategy():
+    transfer_strategy = AsyncMock()
+    transfer_strategy.execute_transfer.return_value = True
+    hangup_strategy = AsyncMock()
+
+    await _serializer(transfer_strategy, hangup_strategy).serialize(
+        EndFrame(reason=EndTaskReason.TRANSFER_CALL.value)
+    )
+
+    transfer_strategy.execute_transfer.assert_awaited_once_with(
+        {"call_id": "call-1", "auth_id": "MA123", "auth_token": "secret"}
+    )
+    hangup_strategy.execute_hangup.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_normal_end_frame_invokes_only_hangup_strategy():
+    transfer_strategy = AsyncMock()
+    hangup_strategy = AsyncMock()
+    hangup_strategy.execute_hangup.return_value = True
+
+    await _serializer(transfer_strategy, hangup_strategy).serialize(EndFrame())
+
+    hangup_strategy.execute_hangup.assert_awaited_once_with(
+        {"call_id": "call-1", "auth_id": "MA123", "auth_token": "secret"}
+    )
+    transfer_strategy.execute_transfer.assert_not_awaited()


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional transfer and hangup strategies to `PlivoFrameSerializer` to control call behavior when the pipeline ends. Supports transfer via `EndTaskReason.TRANSFER_CALL`, with safe one-time execution and clear fallbacks.

- **New Features**
  - Adds optional `transfer_strategy` and `hangup_strategy` constructor params.
  - On `EndFrame`/`CancelFrame` with reason `TRANSFER_CALL`, calls `execute_transfer({call_id, auth_id, auth_token})`; otherwise, if `auto_hang_up`, calls `execute_hangup(...)` or falls back to internal hangup.
  - Ensures strategies run once per call and logs failures; adds tests to verify only the appropriate strategy is invoked.

- **Migration**
  - No breaking changes; existing auto hang-up behavior remains if strategies are not provided.
  - To enable transfers, pass a `transfer_strategy` and emit `EndFrame(reason=EndTaskReason.TRANSFER_CALL.value)`.

<sup>Written for commit 912058271c4e3a38d8f4404104a95a074100ef09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/pipecat/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

