### PR TITLE
fix: ignore muted user speech in TurnTrackingObserver

### DIFF
--- a/src/pipecat/observers/turn_tracking_observer.py
+++ b/src/pipecat/observers/turn_tracking_observer.py
@@ -21,6 +21,8 @@ from pipecat.frames.frames import (
     CancelFrame,
     EndFrame,
     StartFrame,
+    UserMuteStartedFrame,
+    UserMuteStoppedFrame,
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
 )
@@ -42,6 +44,11 @@ class TurnTrackingObserver(BaseObserver):
 
       - The user starts speaking again
       - A timeout period elapses with no more bot speech
+
+    User speaking frames observed while the user is muted are ignored: mute
+    strategies suppress them at the user aggregator, so speech detected during
+    a mute window (e.g. echo of the bot's own audio) must not advance turns or
+    report user speech timing.
     """
 
     def __init__(self, max_frames=100, turn_end_timeout_secs=2.5, **kwargs):
@@ -64,6 +71,7 @@ class TurnTrackingObserver(BaseObserver):
         # audio, so this must be tracked independently from ``_turn_count``.
         self._bot_speaking_turn: int | None = None
         self._user_speaking_turn: int | None = None
+        self._is_user_muted = False
         self._has_bot_spoken = False
         self._turn_start_time = 0
         self._turn_end_timeout_secs = turn_end_timeout_secs
@@ -113,6 +121,10 @@ class TurnTrackingObserver(BaseObserver):
             # Start the first turn immediately when the pipeline starts
             if self._turn_count == 0:
                 await self._start_turn(data)
+        elif isinstance(data.frame, UserMuteStartedFrame):
+            self._is_user_muted = True
+        elif isinstance(data.frame, UserMuteStoppedFrame):
+            self._is_user_muted = False
         elif isinstance(data.frame, UserStartedSpeakingFrame):
             await self._handle_user_started_speaking(data)
         elif isinstance(data.frame, UserStoppedSpeakingFrame):
@@ -157,6 +169,10 @@ class TurnTrackingObserver(BaseObserver):
 
     async def _handle_user_started_speaking(self, data: FramePushed):
         """Handle user speaking events, including interruptions."""
+        if self._is_user_muted:
+            logger.trace(f"Ignoring muted user speech start in Turn {self._turn_count}")
+            return
+
         if self._is_bot_speaking:
             # Handle interruption - end current turn and start a new one
             self._cancel_turn_end_timer()  # Cancel any pending end turn timer
@@ -182,6 +198,13 @@ class TurnTrackingObserver(BaseObserver):
 
     async def _handle_user_stopped_speaking(self, data: FramePushed):
         """Associate the user speech stop with its owning logical turn."""
+        # A stop whose start was suppressed by mute carries no useful timing.
+        # A stop for speech that started before the mute engaged is still
+        # processed so the owning turn's speech state closes correctly.
+        if self._is_user_muted and self._user_speaking_turn is None:
+            logger.trace(f"Ignoring muted user speech stop in Turn {self._turn_count}")
+            return
+
         turn_number = self._user_speaking_turn or self._turn_count
         await self._call_event_handler("on_user_speech_stopped_for_turn", turn_number, data)
         self._user_speaking_turn = None

--- a/tests/test_turn_tracking_observer.py
+++ b/tests/test_turn_tracking_observer.py
@@ -10,6 +10,8 @@ from pipecat.frames.frames import (
     BotStartedSpeakingFrame,
     BotStoppedSpeakingFrame,
     CancelFrame,
+    UserMuteStartedFrame,
+    UserMuteStoppedFrame,
     UserStartedSpeakingFrame,
     UserStoppedSpeakingFrame,
 )
@@ -412,6 +414,112 @@ class TestTurnTrackingObserver(unittest.IsolatedAsyncioTestCase):
         ]
         self.assertEqual(turn_events, expected_events)
         self.assertEqual(turn_observer._turn_count, 1)
+
+    async def test_muted_user_speech_is_ignored(self):
+        """Speech detected while the user is muted must not advance turns or report speech.
+
+        Reproduces echo of the bot's own audio being detected as user speech
+        while a mute strategy has the user muted (e.g. during the bot's first
+        utterance on a telephony call with no echo cancellation).
+        """
+        turn_observer = TurnTrackingObserver(turn_end_timeout_secs=0.2)
+        processor = IdentityFilter()
+
+        turn_events = []
+        user_speech_events = []
+
+        @turn_observer.event_handler("on_turn_started")
+        async def on_turn_started(observer, turn_number):
+            turn_events.append(f"Turn {turn_number} started")
+
+        @turn_observer.event_handler("on_turn_ended")
+        async def on_turn_ended(observer, turn_number, duration, was_interrupted):
+            turn_events.append(f"Turn {turn_number} ended (interrupted: {was_interrupted})")
+
+        @turn_observer.event_handler("on_user_speech_started_for_turn")
+        async def on_user_speech_started_for_turn(observer, turn_number, data):
+            user_speech_events.append(("started", turn_number))
+
+        @turn_observer.event_handler("on_user_speech_stopped_for_turn")
+        async def on_user_speech_stopped_for_turn(observer, turn_number, data):
+            user_speech_events.append(("stopped", turn_number))
+
+        frames_to_send = [
+            # Turn 1: bot speaks its greeting with the user muted. Echo of the
+            # bot audio is detected as user speech and must be ignored — it
+            # must not interrupt turn 1 or record user speech timing.
+            BotStartedSpeakingFrame(),
+            UserMuteStartedFrame(),
+            UserStartedSpeakingFrame(),
+            UserStoppedSpeakingFrame(),
+            BotStoppedSpeakingFrame(),
+            UserMuteStoppedFrame(),
+            # Turn 2: the real user reply.
+            UserStartedSpeakingFrame(),
+            UserStoppedSpeakingFrame(),
+        ]
+
+        expected_down_frames = [
+            BotStartedSpeakingFrame,
+            UserMuteStartedFrame,
+            UserStartedSpeakingFrame,
+            UserStoppedSpeakingFrame,
+            BotStoppedSpeakingFrame,
+            UserMuteStoppedFrame,
+            UserStartedSpeakingFrame,
+            UserStoppedSpeakingFrame,
+        ]
+
+        await run_test(
+            processor,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+            observers=[turn_observer],
+        )
+
+        expected_events = [
+            "Turn 1 started",
+            "Turn 1 ended (interrupted: False)",
+            "Turn 2 started",
+        ]
+        self.assertEqual(turn_events, expected_events)
+        self.assertEqual(user_speech_events, [("started", 2), ("stopped", 2)])
+        self.assertEqual(turn_observer._turn_count, 2)
+
+    async def test_user_stop_after_mute_engages_is_still_reported(self):
+        """A stop for speech that started unmuted closes that speech even if mute engaged mid-turn."""
+        turn_observer = TurnTrackingObserver(turn_end_timeout_secs=0.2)
+        processor = IdentityFilter()
+        user_speech_events = []
+
+        @turn_observer.event_handler("on_user_speech_started_for_turn")
+        async def on_user_speech_started_for_turn(observer, turn_number, data):
+            user_speech_events.append(("started", turn_number))
+
+        @turn_observer.event_handler("on_user_speech_stopped_for_turn")
+        async def on_user_speech_stopped_for_turn(observer, turn_number, data):
+            user_speech_events.append(("stopped", turn_number))
+
+        frames_to_send = [
+            UserStartedSpeakingFrame(),
+            UserMuteStartedFrame(),
+            UserStoppedSpeakingFrame(),
+        ]
+
+        expected_down_frames = [
+            UserStartedSpeakingFrame,
+            UserMuteStartedFrame,
+            UserStoppedSpeakingFrame,
+        ]
+
+        await run_test(
+            processor,
+            frames_to_send=frames_to_send,
+            expected_down_frames=expected_down_frames,
+            observers=[turn_observer],
+        )
+
+        self.assertEqual(user_speech_events, [("started", 1), ("stopped", 1)])
 
     async def test_end_frame_with_no_active_turn(self):
         """Test that EndFrame doesn't cause issues when no turn is active."""


### PR DESCRIPTION
Mute strategies suppress user speaking frames at the user aggregator, but TurnTrackingObserver observes frames at the source push, before the mute gate. Speech detected while the user was muted (e.g. echo of the bot's own greeting on a telephony call) ended the active turn as interrupted, started a phantom turn, and reported a user speech start for it. The transcript coordinator then kept that early phantom timestamp for the turn's real utterance, recording user turns that appear to start many seconds before the user actually spoke.

Track UserMuteStartedFrame/UserMuteStoppedFrame and ignore user speaking frames while muted. A stop whose start was seen before mute engaged is still processed so the owning turn's speech state closes correctly.

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore muted user speech in TurnTrackingObserver to prevent phantom turns and early user speech timestamps caused by echo. We now track mute frames and still close speech correctly if a stop follows a start that happened before mute.

- **Bug Fixes**
  - Track `UserMuteStartedFrame`/`UserMuteStoppedFrame` and set a muted flag.
  - Skip `UserStartedSpeakingFrame` while muted; ignore `UserStoppedSpeakingFrame` if no prior unmuted start.
  - Added tests for muted echo during bot speech and for stop-after-mute scenarios.

<sup>Written for commit 1f5392c3f99982f81d2163a7c36958205c9f0f69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/pipecat/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

