### PR TITLE
fix: skip debounce for finalized external turns

### DIFF
--- a/src/pipecat/turns/user_stop/external_user_turn_stop_strategy.py
+++ b/src/pipecat/turns/user_stop/external_user_turn_stop_strategy.py
@@ -55,6 +55,7 @@ class ExternalUserTurnStopStrategy(BaseUserTurnStopStrategy):
         self._seen_interim_results = False
         self._event = asyncio.Event()
         self._task: asyncio.Task | None = None
+        self._external_stop_received = False
 
     @property
     def wait_for_transcript(self) -> bool:
@@ -71,6 +72,7 @@ class ExternalUserTurnStopStrategy(BaseUserTurnStopStrategy):
         self._text = ""
         self._user_speaking = False
         self._seen_interim_results = False
+        self._external_stop_received = False
         self._event.clear()
 
     async def setup(self, task_manager: BaseTaskManager):
@@ -115,10 +117,15 @@ class ExternalUserTurnStopStrategy(BaseUserTurnStopStrategy):
     async def _handle_user_started_speaking(self, _: UserStartedSpeakingFrame):
         """Handle when the external service indicates the user is speaking."""
         self._user_speaking = True
+        self._text = ""
+        self._seen_interim_results = False
+        self._external_stop_received = False
+        self._event.clear()
 
     async def _handle_user_stopped_speaking(self, _: UserStoppedSpeakingFrame):
         """Handle when the external service indicates the user has stopped speaking."""
         self._user_speaking = False
+        self._external_stop_received = True
         await self._maybe_trigger_user_turn_stopped()
 
     async def _handle_interim_transcription(self, frame: InterimTranscriptionFrame):
@@ -129,7 +136,23 @@ class ExternalUserTurnStopStrategy(BaseUserTurnStopStrategy):
         self._text += frame.text
         # We just got a final result, so let's reset interim results.
         self._seen_interim_results = False
-        # Reset aggregation timer.
+
+        # UserStoppedSpeakingFrame is a high-priority SystemFrame and can overtake
+        # a finalized transcript that the STT queued first. Once that finalized
+        # transcript arrives, no more transcript chunks are expected for this
+        # utterance, so waiting for the aggregation timeout only adds latency.
+        if (
+            self._wait_for_transcript
+            and self._external_stop_received
+            and not self._user_speaking
+            and frame.finalized
+            and self._text.strip()
+        ):
+            await self._maybe_trigger_user_turn_stopped()
+            return
+
+        # Preserve the debounce for non-finalized transcripts, which may be
+        # followed by additional transcription chunks.
         self._event.set()
 
     async def _task_handler(self):

--- a/tests/test_user_turn_stop_strategy.py
+++ b/tests/test_user_turn_stop_strategy.py
@@ -789,6 +789,77 @@ class TestExternalUserTurnStopStrategy(unittest.IsolatedAsyncioTestCase):
         await strategy.process_frame(UserStoppedSpeakingFrame())
         self.assertTrue(should_start)
 
+    async def test_finalized_transcript_after_external_stop_triggers_immediately(self):
+        """A stop frame overtaking its finalized transcript must not add the debounce."""
+        strategy = ExternalUserTurnStopStrategy(timeout=10.0)
+        stopped = False
+
+        @strategy.event_handler("on_user_turn_stopped")
+        async def on_user_turn_stopped(strategy, params):
+            nonlocal stopped
+            stopped = True
+
+        await strategy.process_frame(UserStartedSpeakingFrame())
+        await strategy.process_frame(
+            InterimTranscriptionFrame(text="How are you?", user_id="cat", timestamp="")
+        )
+        await strategy.process_frame(UserStoppedSpeakingFrame())
+        self.assertFalse(stopped)
+
+        await strategy.process_frame(
+            TranscriptionFrame(
+                text="How are you?",
+                user_id="cat",
+                timestamp="",
+                finalized=True,
+            )
+        )
+        self.assertTrue(stopped)
+
+    async def test_non_finalized_transcript_after_external_stop_keeps_debounce(self):
+        strategy = ExternalUserTurnStopStrategy(timeout=10.0)
+        stopped = False
+
+        @strategy.event_handler("on_user_turn_stopped")
+        async def on_user_turn_stopped(strategy, params):
+            nonlocal stopped
+            stopped = True
+
+        await strategy.process_frame(UserStartedSpeakingFrame())
+        await strategy.process_frame(UserStoppedSpeakingFrame())
+        await strategy.process_frame(
+            TranscriptionFrame(text="First chunk", user_id="cat", timestamp="")
+        )
+
+        self.assertFalse(stopped)
+
+    async def test_new_external_start_clears_pending_stop_before_finalized_transcript(self):
+        strategy = ExternalUserTurnStopStrategy(timeout=10.0)
+        stopped = False
+
+        @strategy.event_handler("on_user_turn_stopped")
+        async def on_user_turn_stopped(strategy, params):
+            nonlocal stopped
+            stopped = True
+
+        await strategy.process_frame(UserStartedSpeakingFrame())
+        await strategy.process_frame(UserStoppedSpeakingFrame())
+        self.assertFalse(stopped)
+
+        # Speech resumed before the delayed finalized transcript arrived. The
+        # previous chunk's external stop must no longer arm the fast path.
+        await strategy.process_frame(UserStartedSpeakingFrame())
+        await strategy.process_frame(
+            TranscriptionFrame(
+                text="How are you?",
+                user_id="cat",
+                timestamp="",
+                finalized=True,
+            )
+        )
+
+        self.assertFalse(stopped)
+
 
 class TestExternalUserTurnCompletionStopStrategy(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self) -> None:


### PR DESCRIPTION
## Summary
- trigger external turn stop immediately when a finalized transcript arrives after the external stop frame
- retain the transcript aggregation debounce for non-finalized transcript chunks
- reset pending external-stop and transcript state when speech resumes

## Root cause
UserStoppedSpeakingFrame is a high-priority SystemFrame, so it can overtake the finalized TranscriptionFrame that Deepgram Flux queued first. ExternalUserTurnStopStrategy then waited its full 500 ms aggregation timeout even though the arriving transcript was marked finalized.

## Tests
- python -m ruff check src/pipecat/turns/user_stop/external_user_turn_stop_strategy.py tests/test_user_turn_stop_strategy.py
- python -m pytest tests/test_user_turn_stop_strategy.py -q (28 passed)
- Dograh pipeline and Deepgram configuration tests (24 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where an external stop frame could overtake a finalized transcript, adding up to 500 ms latency. Now, finalized transcripts arriving after an external stop finalize the turn immediately.

- **Bug Fixes**
  - Trigger user turn stop immediately when a finalized transcript arrives after an external stop.
  - Keep the debounce for non-finalized transcript chunks.
  - Clear pending stop and transcript state when speech resumes.

<sup>Written for commit d27db07008a5d6ea7f04c61891c0df3457c3d2ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/pipecat/pull/53?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

