### PR TITLE
Fix/bound output transport drain

### DIFF
--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -57,6 +57,9 @@ from pipecat.utils.time import nanoseconds_to_seconds
 
 BOT_VAD_STOP_SECS = 0.35
 
+# How often shutdown re-checks whether the audio task is still making progress.
+_DRAIN_POLL_SECS = 0.25
+
 
 class BaseOutputTransport(FrameProcessor):
     """Base class for output transport implementations.
@@ -462,6 +465,9 @@ class BaseOutputTransport(FrameProcessor):
             self._audio_task: asyncio.Task | None = None
             self._video_task: asyncio.Task | None = None
             self._clock_task: asyncio.Task | None = None
+            # Monotonic time of the audio task's last loop iteration. Used at
+            # shutdown to tell a slow drain apart from a wedged one.
+            self._audio_progress_time: float = 0.0
             self._audio_paused = False
             self._audio_resume_event = asyncio.Event()
             self._audio_resume_event.set()
@@ -532,10 +538,41 @@ class BaseOutputTransport(FrameProcessor):
             # that EndFrame to be processed by the audio and clock tasks. We
             # also need to wait for these tasks before cancelling the video task
             # because it might be still rendering.
+            #
+            # The wait is bounded: a peer that has stopped reading parks the
+            # transport write in these tasks with no timeout of its own, and
+            # `process_frame()` only pushes the EndFrame downstream once we
+            # return. An unbounded wait here strands the EndFrame inside this
+            # processor and hangs pipeline shutdown for good.
+            timeout = self._params.audio_out_drain_timeout_secs
             if self._audio_task:
-                await self._audio_task
+                # Bound the stall, not the drain: a long goodbye is paced in
+                # real time and is legitimately slow, so only give up once the
+                # task stops making progress entirely.
+                self._audio_progress_time = time.monotonic()
+                while True:
+                    done, _ = await asyncio.wait({self._audio_task}, timeout=_DRAIN_POLL_SECS)
+                    if done:
+                        break
+                    stalled_for = time.monotonic() - self._audio_progress_time
+                    if stalled_for > timeout:
+                        logger.warning(
+                            f"{self} audio task made no progress for {stalled_for:.1f}s "
+                            f"(peer not reading?); cancelling it so {frame} can continue "
+                            "downstream"
+                        )
+                        await self._cancel_audio_task()
+                        break
             if self._clock_task:
-                await self._clock_task
+                # The clock task returns as soon as it pops the EndFrame, so a
+                # flat bound is enough here.
+                done, _ = await asyncio.wait({self._clock_task}, timeout=timeout)
+                if not done:
+                    logger.warning(
+                        f"{self} clock task did not drain in {timeout}s; cancelling it so "
+                        f"{frame} can continue downstream"
+                    )
+                    await self._cancel_clock_task()
 
             # Stop audio mixer.
             if self._mixer:
@@ -913,6 +950,10 @@ class BaseOutputTransport(FrameProcessor):
             sleep_between_consecutive_failures = self._params.audio_out_sleep_between_failures
 
             async for frame in self._next_frame():
+                # Mark forward progress so shutdown can distinguish a long but
+                # healthy drain from a task wedged in a transport write.
+                self._audio_progress_time = time.monotonic()
+
                 # No need to push EndFrame, it's pushed from process_frame().
                 if isinstance(frame, EndFrame):
                     # Send some final silence so words don't cut out.

--- a/src/pipecat/transports/base_output.py
+++ b/src/pipecat/transports/base_output.py
@@ -56,9 +56,7 @@ from pipecat.utils.frame_queue import FrameQueue
 from pipecat.utils.time import nanoseconds_to_seconds
 
 BOT_VAD_STOP_SECS = 0.35
-
-# How often shutdown re-checks whether the audio task is still making progress.
-_DRAIN_POLL_SECS = 0.25
+DRAIN_POLL_SECS = 0.25
 
 
 class BaseOutputTransport(FrameProcessor):
@@ -465,8 +463,6 @@ class BaseOutputTransport(FrameProcessor):
             self._audio_task: asyncio.Task | None = None
             self._video_task: asyncio.Task | None = None
             self._clock_task: asyncio.Task | None = None
-            # Monotonic time of the audio task's last loop iteration. Used at
-            # shutdown to tell a slow drain apart from a wedged one.
             self._audio_progress_time: float = 0.0
             self._audio_paused = False
             self._audio_resume_event = asyncio.Event()
@@ -539,19 +535,14 @@ class BaseOutputTransport(FrameProcessor):
             # also need to wait for these tasks before cancelling the video task
             # because it might be still rendering.
             #
-            # The wait is bounded: a peer that has stopped reading parks the
-            # transport write in these tasks with no timeout of its own, and
-            # `process_frame()` only pushes the EndFrame downstream once we
-            # return. An unbounded wait here strands the EndFrame inside this
-            # processor and hangs pipeline shutdown for good.
+            # Transport writes are unbounded, so wait on progress rather than on
+            # elapsed time: queued audio plays out in real time and a slow drain
+            # is normal, but a stalled one never completes.
             timeout = self._params.audio_out_drain_timeout_secs
             if self._audio_task:
-                # Bound the stall, not the drain: a long goodbye is paced in
-                # real time and is legitimately slow, so only give up once the
-                # task stops making progress entirely.
                 self._audio_progress_time = time.monotonic()
                 while True:
-                    done, _ = await asyncio.wait({self._audio_task}, timeout=_DRAIN_POLL_SECS)
+                    done, _ = await asyncio.wait({self._audio_task}, timeout=DRAIN_POLL_SECS)
                     if done:
                         break
                     stalled_for = time.monotonic() - self._audio_progress_time
@@ -564,8 +555,6 @@ class BaseOutputTransport(FrameProcessor):
                         await self._cancel_audio_task()
                         break
             if self._clock_task:
-                # The clock task returns as soon as it pops the EndFrame, so a
-                # flat bound is enough here.
                 done, _ = await asyncio.wait({self._clock_task}, timeout=timeout)
                 if not done:
                     logger.warning(
@@ -950,8 +939,7 @@ class BaseOutputTransport(FrameProcessor):
             sleep_between_consecutive_failures = self._params.audio_out_sleep_between_failures
 
             async for frame in self._next_frame():
-                # Mark forward progress so shutdown can distinguish a long but
-                # healthy drain from a task wedged in a transport write.
+                # Progress signal for the drain in stop().
                 self._audio_progress_time = time.monotonic()
 
                 # No need to push EndFrame, it's pushed from process_frame().

--- a/src/pipecat/transports/base_transport.py
+++ b/src/pipecat/transports/base_transport.py
@@ -38,6 +38,13 @@ class TransportParams(BaseModel):
             When False, the transport will wait for audio data instead of inserting silence.
         audio_out_max_consecutive_failures: Max failure of transport write before givingup
         audio_out_sleep_between_failures: Sleep interval between subsequent failures
+        audio_out_drain_timeout_secs: Maximum time to wait for pending output audio to
+            drain when an ``EndFrame`` stops the transport. A peer that has stopped
+            reading (half-open socket, or a telephony call already torn down on the
+            provider's side) parks the transport write with no timeout of its own, which
+            would otherwise block ``EndFrame`` inside the transport and hang pipeline
+            shutdown. On expiry the audio and clock tasks are cancelled so the
+            ``EndFrame`` continues downstream.
         bot_vad_stop_secs: Fallback timeout (in seconds) used to mark the bot as
             stopped speaking when no explicit ``TTSStoppedFrame`` arrives (e.g.
             for realtime/speech-to-speech LLMs). Lower this for realtime models
@@ -80,6 +87,7 @@ class TransportParams(BaseModel):
     audio_out_auto_silence: bool = True
     audio_out_max_consecutive_failures: int = 10
     audio_out_sleep_between_failures: float = 0.5
+    audio_out_drain_timeout_secs: float = 5.0
     bot_vad_stop_secs: float = 3.0
     audio_in_enabled: bool = False
     audio_in_sample_rate: int | None = None

--- a/src/pipecat/transports/base_transport.py
+++ b/src/pipecat/transports/base_transport.py
@@ -38,13 +38,9 @@ class TransportParams(BaseModel):
             When False, the transport will wait for audio data instead of inserting silence.
         audio_out_max_consecutive_failures: Max failure of transport write before givingup
         audio_out_sleep_between_failures: Sleep interval between subsequent failures
-        audio_out_drain_timeout_secs: Maximum time to wait for pending output audio to
-            drain when an ``EndFrame`` stops the transport. A peer that has stopped
-            reading (half-open socket, or a telephony call already torn down on the
-            provider's side) parks the transport write with no timeout of its own, which
-            would otherwise block ``EndFrame`` inside the transport and hang pipeline
-            shutdown. On expiry the audio and clock tasks are cancelled so the
-            ``EndFrame`` continues downstream.
+        audio_out_drain_timeout_secs: How long the audio task may make no progress
+            before an ``EndFrame`` stops waiting for it and cancels it. Bounds the
+            stall rather than the total drain, so long queued playout still flushes.
         bot_vad_stop_secs: Fallback timeout (in seconds) used to mark the bot as
             stopped speaking when no explicit ``TTSStoppedFrame`` arrives (e.g.
             for realtime/speech-to-speech LLMs). Lower this for realtime models

--- a/tests/test_base_output_transport.py
+++ b/tests/test_base_output_transport.py
@@ -353,10 +353,8 @@ class TestBaseOutputTransportShutdown(unittest.IsolatedAsyncioTestCase):
     async def test_end_frame_proceeds_when_audio_write_never_returns(self):
         """A wedged transport write must not strand the EndFrame.
 
-        Transport writes have no timeout of their own, so a peer that has
-        stopped reading parks the audio task forever. `process_frame()` pushes
-        the EndFrame downstream only after `stop()` returns, so an unbounded
-        wait there hangs pipeline shutdown permanently.
+        `process_frame()` pushes the EndFrame downstream only after `stop()`
+        returns, so a write that never completes must not block `stop()`.
         """
         transport = await self._make_transport(audio_out_drain_timeout_secs=0.5)
         never_returns = asyncio.Event()

--- a/tests/test_base_output_transport.py
+++ b/tests/test_base_output_transport.py
@@ -328,3 +328,85 @@ class TestBaseOutputTransportInterruptions(unittest.IsolatedAsyncioTestCase):
         finally:
             if not stopped:
                 await transport.cancel(CancelFrame())
+
+
+class TestBaseOutputTransportShutdown(unittest.IsolatedAsyncioTestCase):
+    async def _make_transport(self, **param_kwargs) -> BaseOutputTransport:
+        params = TransportParams(audio_out_enabled=True, **param_kwargs)
+        transport = BaseOutputTransport(params)
+        transport.push_frame = AsyncMock()
+
+        task_manager = TaskManager()
+        task_manager.setup(TaskManagerParams(loop=asyncio.get_event_loop()))
+        await transport.setup(
+            FrameProcessorSetup(
+                clock=SystemClock(),
+                task_manager=task_manager,
+                pipeline_worker=SimpleNamespace(app_resources=None),  # type: ignore[arg-type]
+            )
+        )
+        start_frame = StartFrame(audio_out_sample_rate=16000)
+        await transport.process_frame(start_frame, FrameDirection.DOWNSTREAM)
+        await transport.set_transport_ready(start_frame)
+        return transport
+
+    async def test_end_frame_proceeds_when_audio_write_never_returns(self):
+        """A wedged transport write must not strand the EndFrame.
+
+        Transport writes have no timeout of their own, so a peer that has
+        stopped reading parks the audio task forever. `process_frame()` pushes
+        the EndFrame downstream only after `stop()` returns, so an unbounded
+        wait there hangs pipeline shutdown permanently.
+        """
+        transport = await self._make_transport(audio_out_drain_timeout_secs=0.5)
+        never_returns = asyncio.Event()
+
+        async def wedged_write(_frame):
+            await never_returns.wait()  # never set: models a peer that stopped reading
+            return True
+
+        transport.write_audio_frame = AsyncMock(side_effect=wedged_write)
+
+        # Queue several full chunks so the audio task is inside the wedged
+        # write, with more still queued, when the EndFrame arrives.
+        chunk = transport._media_senders[None].audio_chunk_size
+        await transport.process_frame(
+            OutputAudioRawFrame(audio=b"\x00" * (chunk * 5), sample_rate=16000, num_channels=1),
+            FrameDirection.DOWNSTREAM,
+        )
+        await asyncio.sleep(0.2)
+        self.assertGreater(transport.write_audio_frame.call_count, 0, "audio task never started")
+
+        end_frame = EndFrame()
+        await asyncio.wait_for(
+            transport.process_frame(end_frame, FrameDirection.DOWNSTREAM),
+            timeout=10.0,
+        )
+
+        pushed = [call.args[0] for call in transport.push_frame.call_args_list]
+        self.assertIn(end_frame, pushed, "EndFrame must still be pushed downstream")
+
+    async def test_slow_but_progressing_drain_is_not_cancelled(self):
+        """A long playout is legitimately slow and must not be cut short."""
+        transport = await self._make_transport(audio_out_drain_timeout_secs=0.5)
+
+        async def slow_write(_frame):
+            await asyncio.sleep(0.2)  # slower than a chunk, faster than the stall bound
+            return True
+
+        transport.write_audio_frame = AsyncMock(side_effect=slow_write)
+
+        sender = transport._media_senders[None]
+        chunk = sender.audio_chunk_size
+        for _ in range(10):
+            await transport.process_frame(
+                OutputAudioRawFrame(audio=b"\x00" * chunk, sample_rate=16000, num_channels=1),
+                FrameDirection.DOWNSTREAM,
+            )
+
+        await asyncio.wait_for(
+            transport.process_frame(EndFrame(), FrameDirection.DOWNSTREAM), timeout=30.0
+        )
+
+        # Drained on its own rather than being cancelled by the stall bound.
+        self.assertTrue(sender._audio_queue.empty())


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent EndFrame from getting stuck when a peer stops reading by bounding the output drain on lack of progress. Adds a stall-based timeout so wedged audio/clock tasks are cancelled and shutdown completes.

- **Bug Fixes**
  - Added `TransportParams.audio_out_drain_timeout_secs` (default 5s) to cap how long the audio task can make no progress. It does not cap total drain time.
  - `BaseOutputTransport.stop()` now monitors audio progress and cancels the audio task if stalled; also cancels the clock task if it doesn’t drain in time.
  - `_audio_task_handler` updates a progress timestamp on each frame.
  - Tests ensure a wedged write doesn’t strand the EndFrame and a slow-but-progressing drain is not cancelled.

<sup>Written for commit 0a792b6b6b761c9cad24a82c87de42857a69ead4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/pipecat/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

