### PR TITLE
Fixed Flow issue for 4.3 testing E2E

### DIFF
--- a/src/pipecat/processors/aggregators/llm_response_universal.py
+++ b/src/pipecat/processors/aggregators/llm_response_universal.py
@@ -136,6 +136,10 @@ class LLMUserAggregatorParams:
         user_mute_strategies: List of user mute strategies.
         user_turn_stop_timeout: Time in seconds to wait before considering the
             user's turn finished.
+        finalized_transcript_vad_recovery_timeout: Grace period in seconds before
+            recovering a final STT transcription whose matching local VAD stop
+            frame was lost. Fresh later transcription cancels the recovery. Set
+            to 0 to disable it.
         user_idle_timeout: Timeout in seconds for detecting user idle state.
             The aggregator will emit an `on_user_turn_idle` event when the user
             has been idle (not speaking) for this duration. Set to 0 to disable
@@ -167,6 +171,7 @@ class LLMUserAggregatorParams:
     user_turn_strategies: UserTurnStrategies | None = None
     user_mute_strategies: list[BaseUserMuteStrategy] = field(default_factory=list)
     user_turn_stop_timeout: float = 5.0
+    finalized_transcript_vad_recovery_timeout: float = 0.0
     user_idle_timeout: float = 0
     vad_analyzer: VADAnalyzer | None = None
     filter_incomplete_user_turns: bool = False
@@ -720,6 +725,9 @@ class LLMUserAggregator(LLMContextAggregator):
         self._user_turn_controller = UserTurnController(
             user_turn_strategies=user_turn_strategies,
             user_turn_stop_timeout=self._params.user_turn_stop_timeout,
+            finalized_transcript_vad_recovery_timeout=(
+                self._params.finalized_transcript_vad_recovery_timeout
+            ),
         )
         self._user_turn_controller.add_event_handler("on_push_frame", self._on_push_frame)
         self._user_turn_controller.add_event_handler("on_broadcast_frame", self._on_broadcast_frame)

--- a/src/pipecat/services/deepgram/stt.py
+++ b/src/pipecat/services/deepgram/stt.py
@@ -744,6 +744,7 @@ class DeepgramSTTService(STTService):
                 # Check if this response is from a finalize() call.
                 # Only mark as finalized when both we requested it AND Deepgram confirms it.
                 from_finalize = getattr(message, "from_finalize", False) or False
+                speech_final = getattr(message, "speech_final", False) or False
                 if from_finalize:
                     self.confirm_finalize()
                 if len(transcript) > 0:
@@ -757,6 +758,10 @@ class DeepgramSTTService(STTService):
                             time_now_iso8601(),
                             language,
                             result=message,
+                            # Deepgram's ``speech_final`` is its provider-level
+                            # end-of-utterance signal. A response to our explicit
+                            # Finalize request is also a completed utterance.
+                            finalized=bool(speech_final or from_finalize),
                         )
                     )
                     await self._handle_transcription(transcript, is_final, language)

--- a/src/pipecat/turns/user_turn_controller.py
+++ b/src/pipecat/turns/user_turn_controller.py
@@ -81,6 +81,7 @@ class UserTurnController(BaseObject):
         *,
         user_turn_strategies: UserTurnStrategies,
         user_turn_stop_timeout: float = 5.0,
+        finalized_transcript_vad_recovery_timeout: float = 0.0,
     ):
         """Initialize the user turn controller.
 
@@ -88,17 +89,28 @@ class UserTurnController(BaseObject):
             user_turn_strategies: Configured strategies for starting and stopping user turns.
             user_turn_stop_timeout: Timeout in seconds to automatically stop a user turn
                 if no activity is detected.
+            finalized_transcript_vad_recovery_timeout: Grace period in seconds before
+                completing a turn when an STT provider has emitted a final
+                transcription segment but the local VAD has not emitted its
+                corresponding stop event. Fresh interim or final transcription
+                cancels and re-arms the grace period. Set to 0 to disable this
+                recovery.
         """
         super().__init__()
 
         self._user_turn_strategies = user_turn_strategies
         self._user_turn_stop_timeout = user_turn_stop_timeout
+        self._finalized_transcript_vad_recovery_timeout = (
+            finalized_transcript_vad_recovery_timeout
+        )
 
         self._user_speaking = False
 
         self._user_turn = False
         self._user_turn_stop_timeout_event = asyncio.Event()
         self._user_turn_stop_timeout_task: asyncio.Task | None = None
+        self._finalized_transcript_vad_recovery_task: asyncio.Task | None = None
+        self._finalized_transcript_vad_recovery_generation = 0
 
         self._register_event_handler("on_push_frame", sync=True)
         self._register_event_handler("on_broadcast_frame", sync=True)
@@ -135,6 +147,8 @@ class UserTurnController(BaseObject):
         if self._user_turn_stop_timeout_task:
             await self.cancel_task(self._user_turn_stop_timeout_task)
             self._user_turn_stop_timeout_task = None
+
+        await self._cancel_finalized_transcript_vad_recovery()
 
         await self._cleanup_strategies()
 
@@ -247,24 +261,28 @@ class UserTurnController(BaseObject):
 
     async def _handle_user_started_speaking(self, frame: UserStartedSpeakingFrame):
         self._user_speaking = True
+        await self._cancel_finalized_transcript_vad_recovery()
 
         # The user started talking, let's reset the user turn timeout.
         self._user_turn_stop_timeout_event.set()
 
     async def _handle_user_stopped_speaking(self, frame: UserStoppedSpeakingFrame):
         self._user_speaking = False
+        await self._cancel_finalized_transcript_vad_recovery()
 
         # The user stopped talking, let's reset the user turn timeout.
         self._user_turn_stop_timeout_event.set()
 
     async def _handle_vad_user_started_speaking(self, frame: VADUserStartedSpeakingFrame):
         self._user_speaking = True
+        await self._cancel_finalized_transcript_vad_recovery()
 
         # The user started talking, let's reset the user turn timeout.
         self._user_turn_stop_timeout_event.set()
 
     async def _handle_vad_user_stopped_speaking(self, frame: VADUserStoppedSpeakingFrame):
         self._user_speaking = False
+        await self._cancel_finalized_transcript_vad_recovery()
 
         # The user stopped talking, let's reset the user turn timeout.
         self._user_turn_stop_timeout_event.set()
@@ -272,6 +290,71 @@ class UserTurnController(BaseObject):
     async def _handle_transcription(self, frame: TranscriptionFrame | InterimTranscriptionFrame):
         # We have received a transcription, let's reset the user turn timeout.
         self._user_turn_stop_timeout_event.set()
+
+        # An interim means the caller is still producing speech. Never let a
+        # prior recovery close that continued turn.
+        if not isinstance(frame, TranscriptionFrame):
+            await self._cancel_finalized_transcript_vad_recovery()
+            return
+
+        await self._schedule_finalized_transcript_vad_recovery()
+
+    async def _cancel_finalized_transcript_vad_recovery(self):
+        """Cancel a pending fallback for a missing local VAD stop event."""
+        self._finalized_transcript_vad_recovery_generation += 1
+        if self._finalized_transcript_vad_recovery_task:
+            await self.cancel_task(self._finalized_transcript_vad_recovery_task)
+            self._finalized_transcript_vad_recovery_task = None
+
+    async def _schedule_finalized_transcript_vad_recovery(self):
+        """Recover only when a final STT transcription is stranded.
+
+        Local VAD remains the normal source of turn completion. This narrowly
+        handles a transport/browser failure where the STT provider has completed
+        a transcription segment but the matching VAD stop frame never reaches
+        the pipeline. Any later transcript cancels the pending recovery, so a
+        caller continuing the same thought is not interrupted.
+        """
+        if (
+            self._finalized_transcript_vad_recovery_timeout <= 0
+            or not self._user_turn
+            or not self._user_speaking
+        ):
+            return
+
+        await self._cancel_finalized_transcript_vad_recovery()
+        generation = self._finalized_transcript_vad_recovery_generation
+        self._finalized_transcript_vad_recovery_task = self.create_task(
+            self._finalized_transcript_vad_recovery_handler(generation),
+            f"{self}::_finalized_transcript_vad_recovery_handler",
+        )
+
+    async def _finalized_transcript_vad_recovery_handler(self, generation: int):
+        try:
+            await asyncio.sleep(self._finalized_transcript_vad_recovery_timeout)
+        except asyncio.CancelledError:
+            return
+        finally:
+            if generation == self._finalized_transcript_vad_recovery_generation:
+                self._finalized_transcript_vad_recovery_task = None
+
+        if (
+            generation != self._finalized_transcript_vad_recovery_generation
+            or not self._user_turn
+            or not self._user_speaking
+        ):
+            return
+
+        logger.warning(
+            f"{self}: final STT transcription did not receive a VAD stop within "
+            f"{self._finalized_transcript_vad_recovery_timeout}s; completing the user turn"
+        )
+        self._user_speaking = False
+        self._user_turn_stop_timeout_event.set()
+        await self._trigger_user_turn_inference_triggered(None)
+        await self._trigger_user_turn_stop(
+            None, UserTurnStoppedParams(enable_user_speaking_frames=True)
+        )
 
     async def _on_push_frame(
         self,

--- a/tests/test_deepgram_stt.py
+++ b/tests/test_deepgram_stt.py
@@ -257,7 +257,7 @@ async def test_connection_handler_backs_off_after_non_quick_failure(monkeypatch)
     assert sleep_calls == [4, 4]  # exponential_backoff_time's min_wait, not skipped
 
 
-def _results_message(transcript: str, is_final: bool):
+def _results_message(transcript: str, is_final: bool, *, speech_final: bool | None = None):
     from deepgram.listen.v1.types import ListenV1Results
 
     return ListenV1Results.model_validate(
@@ -267,7 +267,7 @@ def _results_message(transcript: str, is_final: bool):
             "duration": 1.2,
             "start": 0.0,
             "is_final": is_final,
-            "speech_final": is_final,
+            "speech_final": is_final if speech_final is None else speech_final,
             "channel": {
                 "alternatives": [{"transcript": transcript, "confidence": 0.99, "words": []}]
             },
@@ -307,8 +307,31 @@ async def test_final_transcript_emits_usage_before_transcription_frame(monkeypat
 
     frame_types = [type(f) for f in pushed_frames]
     assert frame_types == [InterimTranscriptionFrame, MetricsFrame, TranscriptionFrame]
+    assert pushed_frames[-1].finalized is True
 
     data = pushed_frames[1].data[0]
     assert isinstance(data, STTUsageMetricsData)
     assert data.value.audio_seconds == 1.25
     assert service._stt_usage_pending_seconds == 0.0
+
+
+@pytest.mark.asyncio
+async def test_segment_final_without_speech_final_is_not_an_utterance_boundary(monkeypatch):
+    """Only Deepgram's end-of-utterance signal finalizes the Pipecat frame."""
+    from pipecat.frames.frames import TranscriptionFrame
+
+    service = DeepgramSTTService(api_key="test-key")
+    pushed_frames = []
+
+    async def fake_push_frame(frame, direction=None):
+        pushed_frames.append(frame)
+
+    monkeypatch.setattr(service, "push_frame", fake_push_frame)
+
+    await service._on_message(
+        _results_message("first segment", is_final=True, speech_final=False)
+    )
+
+    assert len(pushed_frames) == 1
+    assert isinstance(pushed_frames[0], TranscriptionFrame)
+    assert pushed_frames[0].finalized is False

--- a/tests/test_user_turn_controller.py
+++ b/tests/test_user_turn_controller.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 from pipecat.audio.turn.base_turn_analyzer import EndOfTurnState
 from pipecat.frames.frames import (
     BotStartedSpeakingFrame,
+    InterimTranscriptionFrame,
     STTMetadataFrame,
     TranscriptionFrame,
     UserStartedSpeakingFrame,
@@ -263,6 +264,81 @@ class TestUserTurnController(unittest.IsolatedAsyncioTestCase):
         await asyncio.sleep(TRANSCRIPTION_TIMEOUT + 0.1)
 
         self.assertEqual(stop_events, [None])
+        await controller.cleanup()
+
+    async def test_final_transcription_recovers_when_vad_stop_is_lost(self):
+        """A final STT segment must not leave a browser call stuck.
+
+        This reproduces the WebRTC failure mode where STT delivers the caller's
+        final answer but the local VAD never emits a stopped-speaking frame.
+        """
+        controller = UserTurnController(
+            user_turn_strategies=UserTurnStrategies(
+                start=[VADUserTurnStartStrategy()],
+                stop=[SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=1.0)],
+            ),
+            finalized_transcript_vad_recovery_timeout=0.02,
+        )
+        await controller.setup(self.task_manager)
+
+        events: list[str] = []
+
+        @controller.event_handler("on_user_turn_inference_triggered")
+        async def on_user_turn_inference_triggered(controller, strategy):
+            events.append("inference_triggered")
+
+        @controller.event_handler("on_user_turn_stopped")
+        async def on_user_turn_stopped(controller, strategy, params):
+            events.append("stopped")
+
+        await controller.process_frame(VADUserStartedSpeakingFrame())
+        await controller.process_frame(
+            TranscriptionFrame(
+                text="Yes, I am 21 or older.",
+                user_id="caller",
+                timestamp="now",
+                finalized=False,
+            )
+        )
+
+        await asyncio.sleep(0.08)
+        self.assertEqual(events, ["inference_triggered", "stopped"])
+        self.assertFalse(controller.has_active_user_turn)
+
+        await controller.cleanup()
+
+    async def test_new_transcription_cancels_finalized_transcript_recovery(self):
+        """A caller who continues speaking must never be cut off by recovery."""
+        controller = UserTurnController(
+            user_turn_strategies=UserTurnStrategies(
+                start=[VADUserTurnStartStrategy()],
+                stop=[SpeechTimeoutUserTurnStopStrategy(user_speech_timeout=1.0)],
+            ),
+            finalized_transcript_vad_recovery_timeout=0.05,
+        )
+        await controller.setup(self.task_manager)
+
+        stopped = False
+
+        @controller.event_handler("on_user_turn_stopped")
+        async def on_user_turn_stopped(controller, strategy, params):
+            nonlocal stopped
+            stopped = True
+
+        await controller.process_frame(VADUserStartedSpeakingFrame())
+        await controller.process_frame(
+            TranscriptionFrame(text="Yes", user_id="caller", timestamp="now", finalized=True)
+        )
+        await asyncio.sleep(0.01)
+        await controller.process_frame(
+            InterimTranscriptionFrame(text="Yes, and", user_id="caller", timestamp="now")
+        )
+
+        await asyncio.sleep(0.08)
+        self.assertFalse(stopped)
+        self.assertTrue(controller.has_active_user_turn)
+
+        await controller.cleanup()
 
     async def test_user_turn_start_reset(self):
         controller = UserTurnController(


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stuck user turns in Flow 4.3 E2E by adding a recovery window when a final STT transcript arrives but the local VAD stop is lost. Aligns Deepgram finalization with `speech_final` so utterance boundaries are detected correctly.

- **Bug Fixes**
  - Added `finalized_transcript_vad_recovery_timeout` to `UserTurnController` (default 0) and wired it via `LLMUserAggregatorParams`. After a final transcript, if VAD stop is missing, complete the turn after a short grace period; canceled by any new interim/final transcript or speaking frames.
  - Updated `DeepgramSTTService` to set `TranscriptionFrame.finalized` only when Deepgram’s `speech_final` is true or in response to an explicit finalize. Final segments without `speech_final` no longer end the turn.
  - Tests: added coverage for recovery behavior and Deepgram `speech_final` handling; adjusted existing tests accordingly.

<sup>Written for commit 13181d43a5caad57fffc969ad1d282e76d1a1c5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/pipecat/pull/55?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

