### PR TITLE
fix: make Langfuse traces private unless explicitly enabled

### DIFF
--- a/src/pipecat/utils/tracing/langfuse_helpers.py
+++ b/src/pipecat/utils/tracing/langfuse_helpers.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -16,7 +17,13 @@ if TYPE_CHECKING:
 
 
 def mark_trace_public(span: Span) -> None:
-    """Mark the current trace as public for Langfuse sharing."""
+    """Mark the current trace as public for Langfuse sharing.
+
+    Public traces are readable by anyone with the URL, no login required, so
+    this is opt-in via ``LANGFUSE_TRACES_PUBLIC``.
+    """
+    if os.getenv("LANGFUSE_TRACES_PUBLIC", "").strip().lower() not in ("1", "true", "yes"):
+        return
     span.set_attribute("langfuse.trace.public", True)
 
 

--- a/tests/test_langfuse_helpers.py
+++ b/tests/test_langfuse_helpers.py
@@ -1,0 +1,53 @@
+#
+# Copyright (c) 2024-2026, Daily
+#
+# SPDX-License-Identifier: BSD 2-Clause License
+#
+
+import os
+import unittest
+from unittest.mock import patch
+
+from pipecat.utils.tracing.langfuse_helpers import mark_trace_public
+
+
+class _RecordingSpan:
+    """Span stand-in that records the attributes set on it."""
+
+    def __init__(self):
+        self.attributes = {}
+
+    def set_attribute(self, key, value):
+        self.attributes[key] = value
+
+
+class TestMarkTracePublic(unittest.TestCase):
+    """Tests for the LANGFUSE_TRACES_PUBLIC gate on mark_trace_public()."""
+
+    def _mark(self, env):
+        span = _RecordingSpan()
+        # clear=True so an inherited flag can't leak into the test.
+        with patch.dict(os.environ, env, clear=True):
+            mark_trace_public(span)
+        return span
+
+    def test_private_by_default(self):
+        """Traces stay private when the flag is unset."""
+        span = self._mark({})
+        self.assertNotIn("langfuse.trace.public", span.attributes)
+
+    def test_private_when_flag_disabled(self):
+        """An explicit falsy value keeps the trace private."""
+        span = self._mark({"LANGFUSE_TRACES_PUBLIC": "false"})
+        self.assertNotIn("langfuse.trace.public", span.attributes)
+
+    def test_public_when_flag_enabled(self):
+        """The trace is marked public only when the flag opts in."""
+        for value in ("1", "true", "TRUE", "yes"):
+            with self.subTest(value=value):
+                span = self._mark({"LANGFUSE_TRACES_PUBLIC": value})
+                self.assertIs(span.attributes.get("langfuse.trace.public"), True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`mark_trace_public()` currently sets `langfuse.trace.public = true` unconditionally.

Public Langfuse traces can be viewed by **anyone with the trace URL**, without requiring login or project access. This can expose call transcripts, LLM prompts, tool arguments, and knowledge-base content.

Dograh stores the Langfuse trace URL with each workflow run and displays it in the run UI, so the URL is accessible downstream.

## Fix

Gate `langfuse.trace.public` behind the `LANGFUSE_TRACES_PUBLIC` environment variable.

- Default: **private**
- `LANGFUSE_TRACES_PUBLIC=true`: allow public traces
- `LANGFUSE_TRACES_PUBLIC=false`: keep traces private

The check is added inside the shared `mark_trace_public()` helper, so all existing Pipecat call sites are protected automatically.

The environment variable is read inside the function rather than at module import time so it can be overridden cleanly in tests.

When the flag is disabled, the public attribute is **not added at all**, since Langfuse already treats traces as private by default.

## Behaviour Change

Traces are now **private by default**.

Deployments that intentionally rely on unauthenticated Langfuse trace links must explicitly set:

`LANGFUSE_TRACES_PUBLIC=true`

## Tests

Added `tests/test_langfuse_helpers.py` covering:

- Variable unset → private
- `LANGFUSE_TRACES_PUBLIC=false` → private
- `1`, `true`, `TRUE`, `yes` → public

The tests use a minimal recording-span stub and do not require OpenTelemetry setup.

## Verification

- 3 new tests passed
- Tests fail as expected when the new gate is removed, confirming they cover the changed behaviour
- `ruff format --check` passes
- `ruff check` passes
- Existing unrelated failures in `tests/test_turn_trace_observer.py` remain unchanged

## Related

This PR fixes the **Pipecat side** of `dograh-hq/dograh/issues/658`.

A follow-up Dograh PR will:

- Update the Pipecat submodule pointer
- Route `knowledge_base.py:88` through `mark_trace_public()`
- Add the new environment variable to Dograh configuration and documentation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Langfuse traces private by default and require explicit opt-in via `LANGFUSE_TRACES_PUBLIC`. Previously `mark_trace_public()` always set `langfuse.trace.public=true`, making any trace URL readable without login; now it sets the attribute only when the env var is truthy, otherwise leaves it unset.

- Guard implemented in `mark_trace_public()` to cover all call sites automatically.
- Reads `LANGFUSE_TRACES_PUBLIC` at call time; accepted truthy values: `1`, `true`, `yes` (case-insensitive).
- Adds `tests/test_langfuse_helpers.py` covering unset, falsy, and truthy cases.

- Set `LANGFUSE_TRACES_PUBLIC=true` if you rely on public Langfuse trace URLs.
- No action needed for private deployments; traces stay private and the attribute is not set.

<sup>Written for commit 8d54ef5076ee6bce4b6eeffdcc7fd2f51352345f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/pipecat/pull/58?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

