### PR TITLE
fix(tts): use Speechify native PCM sample rate

### DIFF
--- a/src/pipecat/services/speechify/tts.py
+++ b/src/pipecat/services/speechify/tts.py
@@ -40,9 +40,6 @@ CALLER_HEADERS = {
     "X-Pipecat-Version": pipecat_version(),
 }
 
-# PCM rates Speechify can synthesize, as the `pcm_<rate>` output formats.
-SPEECHIFY_PCM_SAMPLE_RATES = (8000, 16000, 22050, 24000, 44100, 48000)
-
 SPEECHIFY_DEFAULT_SAMPLE_RATE = 24000
 
 
@@ -68,23 +65,25 @@ def language_to_speechify_language(language: Language) -> str | None:
 
 
 def _output_format_from_sample_rate(sample_rate: int) -> tuple[str, int]:
-    """Pick the Speechify PCM output format for a sample rate.
+    """Return Speechify's reliable native PCM format and sample rate.
 
     Args:
-        sample_rate: The desired audio sample rate in Hz.
+        sample_rate: The downstream desired sample rate in Hz.
 
     Returns:
-        Tuple of (output_format, sample_rate), where the returned sample rate is the one
-        Speechify will actually synthesize at. It differs from the requested rate when
-        Speechify has no matching PCM format (e.g. 32000 Hz), so callers must stamp the
-        returned rate onto their audio frames and let the output transport resample.
+        Tuple of (output_format, sample_rate) for Speechify's native 24 kHz PCM.
+
+    Speechify returns 24 kHz PCM from the timestamped streaming endpoint even when
+    ``pcm_16000`` is requested and the response header says 16 kHz. Using the native
+    rate explicitly keeps frame metadata truthful; Pipecat's output transport performs
+    any required resampling to the downstream transport rate.
     """
-    if sample_rate in SPEECHIFY_PCM_SAMPLE_RATES:
-        return f"pcm_{sample_rate}", sample_rate
-    logger.warning(
-        f"Speechify has no PCM output format for {sample_rate} Hz, "
-        f"synthesizing at {SPEECHIFY_DEFAULT_SAMPLE_RATE} Hz instead"
-    )
+    if sample_rate != SPEECHIFY_DEFAULT_SAMPLE_RATE:
+        logger.debug(
+            "Speechify synthesizes timestamped PCM at {} Hz; Pipecat will resample to {} Hz",
+            SPEECHIFY_DEFAULT_SAMPLE_RATE,
+            sample_rate,
+        )
     return f"pcm_{SPEECHIFY_DEFAULT_SAMPLE_RATE}", SPEECHIFY_DEFAULT_SAMPLE_RATE
 
 

--- a/tests/test_speechify_tts.py
+++ b/tests/test_speechify_tts.py
@@ -197,15 +197,11 @@ class TestSSEParsing:
 
 
 class TestOutputFormat:
-    """Sample rates map to Speechify's PCM output formats."""
+    """Speechify audio uses its reliable native PCM rate."""
 
-    @pytest.mark.parametrize("sample_rate", [8000, 16000, 22050, 24000, 44100, 48000])
-    def test_supported_sample_rates_pass_through(self, sample_rate):
-        assert _output_format_from_sample_rate(sample_rate) == (f"pcm_{sample_rate}", sample_rate)
-
-    def test_unsupported_sample_rate_falls_back(self):
-        """Speechify has no pcm_32000, so the caller is told the real synthesis rate."""
-        assert _output_format_from_sample_rate(32000) == ("pcm_24000", 24000)
+    @pytest.mark.parametrize("sample_rate", [8000, 16000, 22050, 24000, 32000, 44100, 48000])
+    def test_native_24khz_is_used_for_every_downstream_rate(self, sample_rate):
+        assert _output_format_from_sample_rate(sample_rate) == ("pcm_24000", 24000)
 
 
 class TestLanguageMapping:


### PR DESCRIPTION
## Summary

Speechify timestamped streaming currently returns 24 kHz signed 16-bit mono PCM even when `pcm_16000` is requested and its response header claims 16 kHz. Treating those bytes as 16 kHz makes voices play 1.5x slower and lower-pitched.

This fix always requests Speechify native `pcm_24000` and labels emitted frames as 24 kHz. Pipecat existing output transport then resamples them to the configured 8/16/48 kHz transport rate.

## Validation

- live Dograh WebRTC voice-agent test with Speechify Simba 3.2
- `uv run pytest tests/test_speechify_tts.py -q` (36 passed)
- Ruff check and format check passed
- `git diff --check` passed