### PR TITLE
fix(llm): don't defer function calls on unspeakable content

### DIFF
--- a/src/pipecat/services/google/llm.py
+++ b/src/pipecat/services/google/llm.py
@@ -46,6 +46,7 @@ from pipecat.services.google.utils import update_google_client_http_options
 from pipecat.services.llm_service import FunctionCallFromLLM, LLMService
 from pipecat.services.settings import LLMSettings
 from pipecat.utils.deprecation import deprecated
+from pipecat.utils.text.alnum_utils import has_alnum
 from pipecat.utils.tracing.service_decorators import traced_llm
 from pipecat.utils.types import NOT_GIVEN, NotGiven, assert_given, is_given
 
@@ -676,9 +677,12 @@ class GoogleLLMService(LLMService[GeminiLLMAdapter]):
         grounding_metadata = None
         accumulated_text = ""
 
-        text_generated_signal = False
-
         # Reset pending function calls when processing a new context
+        if self._pending_function_calls:
+            logger.warning(
+                f"{self}: discarding {len(self._pending_function_calls)} "
+                "deferred calls never released by TTS"
+            )
         self._pending_function_calls = []
 
         try:
@@ -735,7 +739,6 @@ class GoogleLLMService(LLMService[GeminiLLMAdapter]):
                                     await self.push_frame(LLMThoughtTextFrame(part.text))
                                     await self.push_frame(LLMThoughtEndFrame())
                                 else:
-                                    text_generated_signal = True
                                     accumulated_text += part.text
                                     await self._push_llm_text(part.text)
                             elif part.function_call:
@@ -866,9 +869,17 @@ class GoogleLLMService(LLMService[GeminiLLMAdapter]):
                     direction=FrameDirection.DOWNSTREAM,
                 )
 
-                # If text was generated, defer function calls until after TTS plays
-                # Otherwise, execute them immediately
-                if text_generated_signal:
+                # Defer function calls until after TTS only for speakable text.
+                # Unspeakable content (whitespace, punctuation, markup) never
+                # produces the BotStoppedSpeakingFrame that releases the
+                # deferral, so it must not count as generated text.
+                text_generated = has_alnum(accumulated_text)
+                if accumulated_text and not text_generated:
+                    logger.info(
+                        f"{self}: no speakable content ({accumulated_text[:120]!r}); "
+                        "running function calls without waiting for TTS"
+                    )
+                if text_generated:
                     self._pending_function_calls = function_calls
                     logger.debug(
                         f"{self}: Deferring {len(function_calls)} function calls until after TTS"

--- a/src/pipecat/services/openai/base_llm.py
+++ b/src/pipecat/services/openai/base_llm.py
@@ -44,6 +44,7 @@ from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.llm_service import FunctionCallFromLLM, LLMService
 from pipecat.services.settings import LLMSettings
 from pipecat.utils.deprecation import deprecated
+from pipecat.utils.text.alnum_utils import has_alnum
 from pipecat.utils.tracing.service_decorators import traced_llm
 from pipecat.utils.types import NOT_GIVEN, NotGiven, assert_given
 
@@ -448,10 +449,17 @@ class BaseOpenAILLMService(LLMService[OpenAILLMAdapter]):
         tool_call_id = ""
 
         # Reset pending node-transition calls when processing a new context.
+        if self._pending_node_transition_function_calls:
+            logger.warning(
+                f"{self}: discarding "
+                f"{len(self._pending_node_transition_function_calls)} deferred "
+                "node-transition calls never released by TTS"
+            )
         self._pending_node_transition_function_calls = []
 
-        # Flag to store whether some text was generated in the current generation
-        text_generated_signal = False
+        # Content generated in the current completion, accumulated so the
+        # deferral decision below can ask whether any of it is speakable.
+        generated_content = ""
 
         await self.start_ttfb_metrics()
 
@@ -550,7 +558,7 @@ class BaseOpenAILLMService(LLMService[OpenAILLMAdapter]):
                             # Keep iterating through the response to collect all the argument fragments
                             arguments += tool_call.function.arguments
                     elif chunk.choices[0].delta.content:
-                        text_generated_signal = True
+                        generated_content += chunk.choices[0].delta.content
                         await self._push_llm_text(chunk.choices[0].delta.content)
 
                     # When gpt-4o-audio / gpt-4o-mini-audio is used for llm or stt+llm
@@ -603,9 +611,18 @@ class BaseOpenAILLMService(LLMService[OpenAILLMAdapter]):
                 direction=FrameDirection.DOWNSTREAM,
             )
 
+            # Unspeakable content (whitespace, punctuation, markup) never
+            # produces the BotStoppedSpeakingFrame that releases a deferred
+            # transition, so it must not count as generated text.
+            text_generated = has_alnum(generated_content)
+            if generated_content and not text_generated:
+                logger.info(
+                    f"{self}: no speakable content ({generated_content[:120]!r}); "
+                    "running function calls without waiting for TTS"
+                )
             await self._run_or_defer_function_calls(
                 function_calls,
-                text_generated=text_generated_signal,
+                text_generated=text_generated,
             )
 
     async def _run_or_defer_function_calls(

--- a/tests/test_openai_llm_function_call_deferral.py
+++ b/tests/test_openai_llm_function_call_deferral.py
@@ -6,6 +6,7 @@
 
 """Tests for node-transition function-call deferral in OpenAI LLM services."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -127,3 +128,133 @@ async def test_pending_node_transition_batch_runs_after_tts():
 
     service.run_function_calls.assert_awaited_once_with([function_call])
     assert service._pending_node_transition_function_calls == []
+
+
+# --- Streaming-level tests for the deferral decision -------------------------
+#
+# The deferral is only released by a BotStoppedSpeakingFrame, so a completion
+# whose content never reaches the synthesizer (whitespace, bare punctuation,
+# markup) must not arm it — models that emit such fragments alongside a
+# node-transition tool call would otherwise park the transition forever and
+# leave the call silent.
+
+
+class _FakeStream:
+    """Stands in for the provider's chat completion stream."""
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+
+    def __aiter__(self):
+        return self._iterate()
+
+    async def _iterate(self):
+        for chunk in self._chunks:
+            yield chunk
+
+    async def close(self):
+        pass
+
+
+def _content_chunk(text: str):
+    return SimpleNamespace(
+        usage=None,
+        model=None,
+        choices=[SimpleNamespace(delta=SimpleNamespace(tool_calls=None, content=text))],
+    )
+
+
+def _tool_call_chunk(name: str, tool_call_id: str = "call-transition"):
+    tool_call = SimpleNamespace(
+        index=0,
+        id=tool_call_id,
+        function=SimpleNamespace(name=name, arguments="{}"),
+    )
+    return SimpleNamespace(
+        usage=None,
+        model=None,
+        choices=[SimpleNamespace(delta=SimpleNamespace(tool_calls=[tool_call], content=None))],
+    )
+
+
+def _streaming_service(chunks) -> OpenAILLMService:
+    service = _make_service()
+    service.get_chat_completions = AsyncMock(return_value=_FakeStream(chunks))
+    service.start_ttfb_metrics = AsyncMock()
+    service.stop_ttfb_metrics = AsyncMock()
+    service.stop_ttfat_metrics = AsyncMock()
+    service._push_llm_text = AsyncMock()
+    service.push_frame = AsyncMock()
+    service.run_function_calls = AsyncMock()
+    service.register_function(
+        "transition_to_next_node",
+        AsyncMock(),
+        is_node_transition=True,
+    )
+    return service
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_content_does_not_defer_node_transition():
+    service = _streaming_service(
+        [_content_chunk("\n"), _tool_call_chunk("transition_to_next_node")]
+    )
+
+    await service._process_context(LLMContext())
+
+    service.run_function_calls.assert_awaited_once()
+    assert service._pending_node_transition_function_calls == []
+
+
+@pytest.mark.asyncio
+async def test_punctuation_only_content_does_not_defer_node_transition():
+    service = _streaming_service(
+        [_content_chunk("..."), _tool_call_chunk("transition_to_next_node")]
+    )
+
+    await service._process_context(LLMContext())
+
+    service.run_function_calls.assert_awaited_once()
+    assert service._pending_node_transition_function_calls == []
+
+
+@pytest.mark.asyncio
+async def test_markup_only_content_does_not_defer_node_transition():
+    service = _streaming_service(
+        [_content_chunk("<break/>"), _tool_call_chunk("transition_to_next_node")]
+    )
+
+    await service._process_context(LLMContext())
+
+    service.run_function_calls.assert_awaited_once()
+    assert service._pending_node_transition_function_calls == []
+
+
+@pytest.mark.asyncio
+async def test_speakable_content_defers_node_transition():
+    service = _streaming_service(
+        [_content_chunk("ठीक है।"), _tool_call_chunk("transition_to_next_node")]
+    )
+
+    await service._process_context(LLMContext())
+
+    service.run_function_calls.assert_not_awaited()
+    pending = service._pending_node_transition_function_calls
+    assert len(pending) == 1
+    assert pending[0].function_name == "transition_to_next_node"
+
+
+@pytest.mark.asyncio
+async def test_speakable_content_split_across_chunks_defers_node_transition():
+    service = _streaming_service(
+        [
+            _content_chunk(" "),
+            _content_chunk("ok"),
+            _tool_call_chunk("transition_to_next_node"),
+        ]
+    )
+
+    await service._process_context(LLMContext())
+
+    service.run_function_calls.assert_not_awaited()
+    assert len(service._pending_node_transition_function_calls) == 1


### PR DESCRIPTION
## Summary

Node-transition function calls are deferred until TTS finishes and released only by a BotStoppedSpeakingFrame. The deferral was armed by any non-empty content delta, but content with nothing speakable (whitespace, bare punctuation, markup) is dropped before synthesis, so the release never came and the call
  went silent at the current node until the user hung up.

Decide with has_alnum() over the accumulated completion content instead, matching what the TTS layer will actually speak. Applies to the OpenAI-compatible base service and the Google service's own copy of the deferral. Also log when content is classified unspeakable and warn when pending deferred calls are
  discarded.

Seen in production with sarvam-105b(-conversations), which emits a whitespace fragment alongside its transition tool call (21 of 22 deferrals never released, runs 693039/693351 et al).

#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.
## Root cause

`_process_context` in `src/pipecat/services/openai/base_llm.py` arms the defer-until-TTS path when *any* non-empty `delta.content` chunk arrived (`text_generated_signal`). The deferred calls are released **only** by a `BotStoppedSpeakingFrame`. But the TTS layer (`tts_service.py` pre/post-filter gates) drops content with nothing speakable — so a completion carrying a tool call plus a whitespace-only fragment arms the deferral while guaranteeing the release event never fires.

Producer-side check ("did content bytes arrive?") and consumer-side reality ("will TTS speak this?") disagree — the deferral deadlocks in the gap. A truly content-free tool call takes the immediate-execution branch and works; the bug needs the in-between case, which is exactly how `sarvam-105b(-conversations)` packages its tool calls most of the time.

`src/pipecat/services/google/llm.py` carries its own copy of the same pattern (same trap, not yet observed to fire in prod).

The deferral mechanism is our fork's addition (fed8541fc, Jul 15) — not upstream pipecat — and the pending list is silently discarded on each new completion, which is why the failure produced no error signal.

## Fix    

- Decide deferral with `has_alnum()` (the existing "anything left to speak here?" predicate) over the accumulated completion content, matching the TTS layer's semantics. Unspeakable-content completions now take the immediate-execution branch, which already works.
- Same change in the Google service's copy.
- New INFO log when content is classified unspeakable (includes the content repr) and WARNING when pending deferred calls are discarded.
- 5 streaming-level regression tests (whitespace / punctuation / markup / Devanagari / split-chunk cases).

Safety: the new defer-set is a strict subset of the old one, so no new deferrals (hence no new deadlocks) can be introduced; behavior for completions with real text in any language is unchanged.

Fixes #61 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a deadlock where node-transition function calls never ran when the completion's content was unspeakable (whitespace, bare punctuation, markup). The deferral used to arm on any non-empty content delta, but unspeakable content is dropped before synthesis, so the `BotStoppedSpeakingFrame` that releases the deferral never arrived and the call stayed silent at the current node.

- Decides deferral with `has_alnum()` over accumulated completion content, matching what the TTS layer will actually speak.
- Applies to the OpenAI-compatible base service and Google's own copy of the deferral.
- Logs when content is classified unspeakable and warns when pending deferred calls are discarded.
- Adds tests covering whitespace, punctuation, markup, and speakable content (including split across chunks).

<sup>Written for commit b58e2965706054fe2428f717f0565880c133ea6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/pipecat/pull/60?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

