### PR TITLE
fix(stt): resolve Dograh speech events through user turn strategies

### DIFF
--- a/src/pipecat/services/dograh/stt.py
+++ b/src/pipecat/services/dograh/stt.py
@@ -17,11 +17,11 @@ from pipecat.frames.frames import (
     ErrorFrame,
     Frame,
     InterimTranscriptionFrame,
+    ProposedUserStartedSpeakingFrame,
+    ProposedUserStoppedSpeakingFrame,
     StartFrame,
     STTMetadataFrame,
     TranscriptionFrame,
-    UserStartedSpeakingFrame,
-    UserStoppedSpeakingFrame,
     VADUserStoppedSpeakingFrame,
 )
 from pipecat.processors.frame_processor import FrameDirection
@@ -87,7 +87,8 @@ class DograhSTTService(WebsocketSTTService):
             correlation_id: Optional server-generated correlation ID for MPS billing v2.
             sample_rate: Audio sample rate in Hz. Defaults to None.
             interim_results: Whether to receive interim transcription results.
-            vad_events: Whether to receive voice activity detection events.
+            vad_events: Whether to receive provider speech events and broadcast turn proposals
+                for the user aggregator to resolve.
             keyterms: Optional list of keyterms for speech recognition boosting.
             settings: STT settings including model and language.
             ttfs_p99_latency: P99 latency from speech end to final transcript in seconds.
@@ -135,7 +136,7 @@ class DograhSTTService(WebsocketSTTService):
         return self._vad_events
 
     def service_metadata_frame(self) -> STTMetadataFrame:
-        """Recommend external turn strategies when Dograh emits VAD events."""
+        """Recommend external turn strategies to resolve provider speech proposals."""
         frame = super().service_metadata_frame()
         if self._vad_events:
             frame.user_turn_strategies = ExternalUserTurnStrategies()
@@ -395,13 +396,13 @@ class DograhSTTService(WebsocketSTTService):
         """Handle speech started event."""
         logger.debug("Speech started detected")
         await self.start_ttfb_metrics()
-        await self.push_frame(UserStartedSpeakingFrame())
+        await self.broadcast_frame(ProposedUserStartedSpeakingFrame)
         await self._call_event_handler("on_speech_started")
 
     async def _handle_speech_ended(self, msg: dict):
         """Handle speech ended event."""
         logger.debug("Speech ended detected")
-        await self.push_frame(UserStoppedSpeakingFrame())
+        await self.broadcast_frame(ProposedUserStoppedSpeakingFrame)
         await self._call_event_handler("on_speech_ended")
 
     async def start(self, frame: StartFrame):

--- a/tests/test_dograh_services.py
+++ b/tests/test_dograh_services.py
@@ -6,18 +6,39 @@
 
 """Tests for Dograh-managed AI services."""
 
+import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from websockets.protocol import State
 
-from pipecat.frames.frames import CancelFrame, EndFrame, TTSStoppedFrame
+from pipecat.frames.frames import (
+    BotStartedSpeakingFrame,
+    CancelFrame,
+    EndFrame,
+    InterruptionFrame,
+    LLMContextFrame,
+    ProposedUserStartedSpeakingFrame,
+    ProposedUserStoppedSpeakingFrame,
+    TranscriptionFrame,
+    TTSStoppedFrame,
+    UserStartedSpeakingFrame,
+    UserStoppedSpeakingFrame,
+)
+from pipecat.pipeline.pipeline import Pipeline
 from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import (
+    LLMUserAggregator,
+    LLMUserAggregatorParams,
+)
+from pipecat.processors.frame_processor import FrameDirection
 from pipecat.services.dograh.flux.stt import DograhFluxSTTService
 from pipecat.services.dograh.llm import DograhLLMService
 from pipecat.services.dograh.stt import DograhSTTService
 from pipecat.services.dograh.tts import DograhTTSService
 from pipecat.services.openai.llm import OpenAILLMService
+from pipecat.tests.utils import SleepFrame, run_test
+from pipecat.turns.user_mute import FirstSpeechUserMuteStrategy
 from pipecat.turns.user_turn_strategies import ExternalUserTurnStrategies
 
 
@@ -42,6 +63,63 @@ def test_stt_metadata_leaves_turn_strategies_unset_without_vad_events():
     frame = service.service_metadata_frame()
 
     assert frame.user_turn_strategies is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("muted", [False, True])
+async def test_stt_speech_proposals_leave_turns_and_interruptions_to_the_aggregator(muted):
+    service = DograhSTTService(api_key="test-key", vad_events=True)
+    messages = [
+        {"type": "speech_started"},
+        {"type": "transcription", "text": "Hello!", "is_final": True},
+        {"type": "speech_ended"},
+    ]
+
+    async def websocket_messages():
+        for message in messages:
+            yield json.dumps(message)
+
+    service._websocket = websocket_messages()
+    service.push_frame = AsyncMock()
+    service.broadcast_interruption = AsyncMock()
+
+    await service._receive_messages()
+
+    pushed = [
+        (call.args[0], call.args[1] if len(call.args) > 1 else FrameDirection.DOWNSTREAM)
+        for call in service.push_frame.await_args_list
+    ]
+    assert [(type(frame), direction) for frame, direction in pushed] == [
+        (ProposedUserStartedSpeakingFrame, FrameDirection.DOWNSTREAM),
+        (ProposedUserStartedSpeakingFrame, FrameDirection.UPSTREAM),
+        (TranscriptionFrame, FrameDirection.DOWNSTREAM),
+        (ProposedUserStoppedSpeakingFrame, FrameDirection.DOWNSTREAM),
+        (ProposedUserStoppedSpeakingFrame, FrameDirection.UPSTREAM),
+    ]
+    service.broadcast_interruption.assert_not_awaited()
+
+    aggregator = LLMUserAggregator(
+        LLMContext(),
+        params=LLMUserAggregatorParams(
+            user_mute_strategies=[FirstSpeechUserMuteStrategy()] if muted else [],
+        ),
+    )
+    frames = [service.service_metadata_frame()]
+    if muted:
+        frames.extend([BotStartedSpeakingFrame(), SleepFrame()])
+    frames.extend(frame for frame, direction in pushed if direction == FrameDirection.DOWNSTREAM)
+    frames.append(SleepFrame(sleep=1.0))
+
+    received_down, received_up = await run_test(
+        Pipeline([aggregator]),
+        frames_to_send=frames,
+    )
+    for received in (received_down, received_up):
+        types = [type(frame) for frame in received]
+        assert types.count(UserStartedSpeakingFrame) == (0 if muted else 1)
+        assert types.count(UserStoppedSpeakingFrame) == (0 if muted else 1)
+        assert types.count(InterruptionFrame) == (0 if muted else 1)
+    assert sum(isinstance(frame, LLMContextFrame) for frame in received_down) == (0 if muted else 1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
#### Please describe the changes in your PR. If it is addressing an issue, please reference that as well.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Dograh speech events so they are resolved through user turn strategies instead of being pushed as direct user turns.

- Broadcasts `ProposedUserStartedSpeakingFrame` and `ProposedUserStoppedSpeakingFrame` instead of pushing `UserStartedSpeakingFrame` and `UserStoppedSpeakingFrame`.
- Lets the user aggregator and mute strategies decide whether to emit turn, interruption, and context frames.
- Adds tests covering both muted and non-muted aggregator behavior.

<sup>Written for commit ab49acbd9507f104f14c5a9bf8e2ba6bcb0d1199. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/dograh-hq/pipecat/pull/62?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

